### PR TITLE
Implemented function `SwapPlusMinus`

### DIFF
--- a/app/Options.hs
+++ b/app/Options.hs
@@ -13,7 +13,8 @@ muOpParser :: ReadM MuOp
 muOpParser = str >>= \s -> case s of
   "ReverseString" -> pure ReverseString
   "ReverseClausesInPatternMatch" -> pure ReverseClausesInPatternMatch
-  _ -> readerError "Accepted mutation operators are: ReverseString, ReverseClausesInPatternMatch"
+  "SwapPlusMinus" -> pure SwapPlusMinus
+  _ -> readerError "Accepted mutation operators are: ReverseString, ReverseClausesInPatternMatch, SwapPlusMinus"
 
 muOpParser' :: Parser MuOp
 muOpParser' = argument muOpParser (metavar "MUOP")

--- a/mendel.cabal
+++ b/mendel.cabal
@@ -24,8 +24,10 @@ extra-doc-files:    CHANGELOG.md
 tested-with:        GHC == 9.2.7 || ==9.4.5 || ==9.6.2
 extra-source-files: test/golden/ReverseString.hs
                     test/golden/ReverseClausesInPatternMatch.hs
+                    test/golden/SwapPlusMinus.hs
                     test/candidate/ReverseString.hs
                     test/candidate/ReverseClausesInPatternMatch.hs
+                    test/candidate/SwapPlusMinus.hs
                     test/temp/.gitkeep
 
 source-repository head

--- a/src/Test/Mendel/Mutation.hs
+++ b/src/Test/Mendel/Mutation.hs
@@ -48,16 +48,16 @@ greverseClauses = mkT reverseClauses
 -------------------------------------------------------------------------------
 
 swapPlusMinusOperator :: Hs.HsExpr GHC.GhcPs -> Hs.HsExpr GHC.GhcPs
-swapPlusMinusOperator (Hs.HsVar x (GHC.L l (GHC.Unqual v))) = Hs.HsVar x (GHC.L l (GHC.Unqual (handleOccName v)))
+swapPlusMinusOperator (Hs.HsVar _ (GHC.L l (GHC.Unqual v))) = Hs.HsVar GHC.NoExtField (GHC.L l (GHC.Unqual (handleOccName v)))
 swapPlusMinusOperator x = x
 
 gswapPlusMinusOperator :: forall a. Typeable a => a -> a
 gswapPlusMinusOperator = mkT swapPlusMinusOperator
 
 handleOccName :: GHC.OccName -> GHC.OccName
-handleOccName x = if x == (GHC.mkVarOcc "+") then (GHC.mkVarOcc "-")
-                  else if x == (GHC.mkVarOcc "-") then (GHC.mkVarOcc "+")
-                  else x
+handleOccName x | x == GHC.mkVarOcc "+" = GHC.mkVarOcc "-"
+                | x == GHC.mkVarOcc "-" = GHC.mkVarOcc "+"
+                | otherwise = x
 
 -------------------------------------------------------------------------------
 -- Combined

--- a/src/Test/Mendel/MutationOperator.hs
+++ b/src/Test/Mendel/MutationOperator.hs
@@ -12,4 +12,5 @@ module Test.Mendel.MutationOperator (MuOp(..)) where
 data MuOp
   = ReverseString
   | ReverseClausesInPatternMatch
+  | SwapPlusMinus
   deriving (Show, Eq)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -18,7 +18,8 @@ main = defaultMain tests
 
 tests :: TestTree
 tests = testGroup "Tests" [ mkGoldenTest "ReverseString" ReverseString
-                          , mkGoldenTest "ReverseClausesInPatternMatch" ReverseClausesInPatternMatch]
+                          , mkGoldenTest "ReverseClausesInPatternMatch" ReverseClausesInPatternMatch
+                          , mkGoldenTest "SwapPlusMinus" SwapPlusMinus]
 
 -------------------------------------------------------------------------------
 -- Directories

--- a/test/candidate/SwapPlusMinus.hs
+++ b/test/candidate/SwapPlusMinus.hs
@@ -1,0 +1,7 @@
+module SwapPlusMinus where
+
+swapPlus :: Num a => a
+swapPlus = 1 + 1
+
+swapMinus :: Num a => a
+swapMinus = 1 - 1

--- a/test/golden/SwapPlusMinus.hs
+++ b/test/golden/SwapPlusMinus.hs
@@ -1,0 +1,6 @@
+module SwapPlusMinus where
+    
+swapPlus :: Num a => a
+swapPlus = 1 - 1
+swapMinus :: Num a => a
+swapMinus = 1 + 1

--- a/test/golden/SwapPlusMinus.hs
+++ b/test/golden/SwapPlusMinus.hs
@@ -1,0 +1,5 @@
+module SwapPlusMinus where
+swapPlus :: Num a => a
+swapPlus = 1 - 1
+swapMinus :: Num a => a
+swapMinus = 1 + 1


### PR DESCRIPTION
Implemented the function `SwapPlusMinus` to change a `(+)` method to `(-)` and `(-)` to `(+)`.

The function can be used for objects with the type `Language.Haskell.Syntax.Expr.HsExpr`. 
The pattern matches only on `HsVar _ (L l (Unqual v))`. v is an `OccName` and gets compared to the OccNames of `+` and `-`. 
If it's equal to one of them it get changed.

I also added the test for the function.   

