### PR TITLE
added MuOp and Config.hs from MuCheck to Mendel

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,7 +5,7 @@ import GHC.Types.SrcLoc qualified as GHC
 import Options (Options (..), parseOptions)
 import Paths_mendel (version)
 import System.Exit (exitFailure, exitSuccess)
-import Test.Mendel.Mutation (mutate)
+import Test.Mendel.Mutation (mutate')
 import Test.Mendel.Parser (parseModule)
 import Test.Mendel.Printer (printOutputable)
 
@@ -26,7 +26,7 @@ dispatch (MutateFile mo fp) = do
             putStrLn "BEFORE"
             putStrLn "-------------------------------------------------------"
             printOutputable hmod
-            let mutant = mutate mo hmod
+            let mutant = mutate' mo hmod
             putStrLn "\n-------------------------------------------------------"
             putStrLn "AFTER"
             putStrLn "-------------------------------------------------------"

--- a/app/Options.hs
+++ b/app/Options.hs
@@ -3,14 +3,15 @@ module Options (Options (..), parseOptions) where
 import Data.Foldable (fold)
 import Options.Applicative
 import Test.Mendel.MutationOperator
+import Test.Mendel.MutationVariant
 
 data Options
-    = MutateFile MuOp FilePath
+    = MutateFile MuVariant FilePath
     | Version
     deriving (Eq, Show)
 
-muOpParser :: ReadM MuOp
-muOpParser =
+muVariantParser :: ReadM MuVariant
+muVariantParser =
     str >>= \s -> case s of
         "ReverseString" -> pure ReverseString
         "ReverseClausesInPatternMatch" -> pure ReverseClausesInPatternMatch
@@ -20,11 +21,11 @@ muOpParser =
             readerError
                 "Accepted mutation operators are: ReverseString, ReverseClausesInPatternMatch, SwapPlusMinus, SwapIfElse"
 
-muOpParser' :: Parser MuOp
-muOpParser' = argument muOpParser (metavar "MUOP")
+muVariantParser' :: Parser MuVariant
+muVariantParser' = argument muVariantParser (metavar "MUOP")
 
 mutateFileParser :: Parser Options
-mutateFileParser = MutateFile <$> muOpParser' <*> argument str (metavar "FILE")
+mutateFileParser = MutateFile <$> muVariantParser' <*> argument str (metavar "FILE")
 
 versionParser :: Parser Options
 versionParser = Version <$ flag' () (long "version" <> help "Display version")

--- a/app/Options.hs
+++ b/app/Options.hs
@@ -2,14 +2,14 @@ module Options (Options (..), parseOptions) where
 
 import Data.Foldable (fold)
 import Options.Applicative
-import Test.Mendel.MutationOperator
+import Test.Mendel.MutationVariant
 
 data Options
-    = MutateFile MuOp FilePath
+    = MutateFile MuVariant FilePath
     | Version
     deriving (Eq, Show)
 
-muOpParser :: ReadM MuOp
+muOpParser :: ReadM MuVariant
 muOpParser =
     str >>= \s -> case s of
         "ReverseString" -> pure ReverseString
@@ -20,7 +20,7 @@ muOpParser =
             readerError
                 "Accepted mutation operators are: ReverseString, ReverseClausesInPatternMatch, SwapPlusMinus, SwapIfElse"
 
-muOpParser' :: Parser MuOp
+muOpParser' :: Parser MuVariant
 muOpParser' = argument muOpParser (metavar "MUOP")
 
 mutateFileParser :: Parser Options

--- a/app/Options.hs
+++ b/app/Options.hs
@@ -2,6 +2,7 @@ module Options (Options (..), parseOptions) where
 
 import Data.Foldable (fold)
 import Options.Applicative
+import Test.Mendel.MutationOperator
 import Test.Mendel.MutationVariant
 
 data Options
@@ -9,8 +10,8 @@ data Options
     | Version
     deriving (Eq, Show)
 
-muOpParser :: ReadM MuVariant
-muOpParser =
+muVariantParser :: ReadM MuVariant
+muVariantParser =
     str >>= \s -> case s of
         "ReverseString" -> pure ReverseString
         "ReverseClausesInPatternMatch" -> pure ReverseClausesInPatternMatch
@@ -20,11 +21,11 @@ muOpParser =
             readerError
                 "Accepted mutation operators are: ReverseString, ReverseClausesInPatternMatch, SwapPlusMinus, SwapIfElse"
 
-muOpParser' :: Parser MuVariant
-muOpParser' = argument muOpParser (metavar "MUOP")
+muVariantParser' :: Parser MuVariant
+muVariantParser' = argument muVariantParser (metavar "MUOP")
 
 mutateFileParser :: Parser Options
-mutateFileParser = MutateFile <$> muOpParser' <*> argument str (metavar "FILE")
+mutateFileParser = MutateFile <$> muVariantParser' <*> argument str (metavar "FILE")
 
 versionParser :: Parser Options
 versionParser = Version <$ flag' () (long "version" <> help "Display version")

--- a/mendel.cabal
+++ b/mendel.cabal
@@ -45,10 +45,13 @@ library
                       Test.Mendel.Printer
                       Test.Mendel.Mutation
                       Test.Mendel.MutationOperator
+                      Test.Mendel.MutationVariant
+                      Test.Mendel.Config
     build-depends:    base >= 4.16 && < 4.20,
                       ghc-lib-parser ==9.6.2.20230523,
                       syb >= 0.7 && < 0.8,
-                      bytestring >=0.11 && < 0.13
+                      bytestring >=0.11 && < 0.13,
+                      ghc-lib-parser-ex 
     hs-source-dirs:   src
     default-language: GHC2021
 

--- a/mendel.cabal
+++ b/mendel.cabal
@@ -45,6 +45,8 @@ library
                       Test.Mendel.Printer
                       Test.Mendel.Mutation
                       Test.Mendel.MutationOperator
+                      Test.Mendel.MutationVariant
+                      Test.Mendel.Config
     build-depends:    base >= 4.16 && < 4.20,
                       ghc-lib-parser ==9.6.2.20230523,
                       syb >= 0.7 && < 0.8,

--- a/src/Test/Mendel/Config.hs
+++ b/src/Test/Mendel/Config.hs
@@ -1,0 +1,133 @@
+{-# LANGUAGE MultiWayIf #-}
+
+-- | Configuration module
+module Test.Mendel.Config where
+
+import Test.Mendel.MutationVariant
+
+{- | For function mutations, whether the function is a symbol or an identifier
+for example,`head` is an identifier while `==` is a symbol.
+-}
+data FnType = FnSymbol | FnIdent
+    deriving (Eq, Show)
+
+{- | User defined function groups. Indicate whether the functions are symbols
+or identifiers, and also the group of functions to interchange for.
+We dont allow mixing of identifiers and functions for now (harder to
+match)
+-}
+data FnOp = FnOp {_type :: FnType, _fns :: [String]}
+    deriving (Eq, Show)
+
+-- | predicates ["pred", "id", "succ"]
+predNums :: [String]
+predNums = ["pred", "id", "succ"]
+
+-- | functions on lists ["sum", "product", "maximum", "minimum", "head", "last"]
+arithLists :: [String]
+arithLists = ["sum", "product", "maximum", "minimum", "head", "last"]
+
+-- | comparison operators ["<", ">", "<=", ">=", "/=", "=="]
+comparators :: [String]
+comparators = ["<", ">", "<=", ">=", "/=", "=="]
+
+-- | binary arithmetic ["+", "-", "*", "/"]
+binAriths :: [String]
+binAriths = ["+", "-", "*", "/"]
+
+{- | The configuration options
+if 1 is provided, all mutants are selected for that kind, and 0 ensures that
+no mutants are picked for that kind. Any fraction in between causes that
+many mutants to be picked randomly from the available pool
+-}
+data Config = Config
+    { -- \| Mutation operators on operator or function replacement
+      muOp :: [FnOp]
+    , -- \| Mutate pattern matches for functions?
+      -- for example
+      --
+      -- > first [] = Nothing
+      -- > first (x:_) = Just x
+      --
+      -- is mutated to
+      --
+      -- > first (x:_) = Just x
+      -- > first [] = Nothing
+      doMutatePatternMatches :: Rational
+    , -- \| Mutates integer values by +1 or -1 or by replacing it with 0 or 1
+      doMutateValues :: Rational
+    , -- \| Mutates operators and functions, that is
+      --
+      -- > i + 1
+      --
+      -- becomes
+      --
+      -- > i - 1
+      --
+      -- > i * 1
+      --
+      -- > i / 1
+      doMutateFunctions :: Rational
+    , -- \| negate if conditions, that is
+      --
+      -- > if True then 1 else 0
+      --
+      -- becomes
+      --
+      -- > if True then 0 else 1
+      doNegateIfElse :: Rational
+    , -- \| negate guarded booleans in guarded definitions
+      --
+      -- > myFn x | x == 1 = True
+      -- > myFn   | otherwise = False
+      --
+      -- becomes
+      --
+      -- > myFn x | not (x == 1) = True
+      -- > myFn   | otherwise = False
+      doNegateGuards :: Rational
+    , -- \| Maximum number of mutants to generate.
+      maxNumMutants :: Int
+    }
+    deriving (Show)
+
+-- | The default configuration
+defaultConfig :: Config
+defaultConfig =
+    Config
+        { muOp =
+            [ FnOp{_type = FnIdent, _fns = predNums}
+            , FnOp{_type = FnIdent, _fns = arithLists}
+            , FnOp{_type = FnSymbol, _fns = comparators}
+            , FnOp{_type = FnSymbol, _fns = binAriths}
+            ]
+        , doMutatePatternMatches = 1.0
+        , doMutateValues = 1.0
+        , doMutateFunctions = 1.0
+        , doNegateIfElse = 1.0
+        , doNegateGuards = 1.0
+        , maxNumMutants = 300
+        }
+
+{- | getSample returns the fraction in config corresponding to the enum passed
+in
+-}
+getSample :: MuVariant -> Config -> Rational
+getSample MutatePatternMatch c = doMutatePatternMatches c
+getSample MutateValues c = doMutateValues c
+getSample MutateFunctions c = doMutateFunctions c
+getSample MutateNegateIfElse c = doNegateIfElse c
+getSample MutateNegateGuards c = doNegateGuards c
+getSample MutateOther{} _c = 1
+
+{- | similarity between two mutation variants. For ease of use, MutateOther is
+treated differently. For MutateOther, if the string is empty, then it is
+matched against any other MutateOther.
+-}
+similar :: MuVariant -> MuVariant -> Bool
+similar (MutateOther a) (MutateOther b) =
+    if
+        | null a -> True
+        | null b -> True
+        | otherwise -> a == b
+similar x y = x == y

--- a/src/Test/Mendel/Config.hs
+++ b/src/Test/Mendel/Config.hs
@@ -109,9 +109,8 @@ defaultConfig =
         , maxNumMutants = 300
         }
 
-{- | getSample returns the fraction in config corresponding to the enum passed
-in
--}
+-- | getSample returns the fraction in config corresponding to the enum passed
+-- in
 getSample :: MuVariant -> Config -> Rational
 getSample MutatePatternMatch c = doMutatePatternMatches c
 getSample MutateValues c = doMutateValues c
@@ -120,14 +119,11 @@ getSample MutateNegateIfElse c = doNegateIfElse c
 getSample MutateNegateGuards c = doNegateGuards c
 getSample MutateOther{} _c = 1
 
-{- | similarity between two mutation variants. For ease of use, MutateOther is
-treated differently. For MutateOther, if the string is empty, then it is
-matched against any other MutateOther.
--}
+-- | similarity between two mutation variants. For ease of use, MutateOther is
+-- treated differently. For MutateOther, if the string is empty, then it is
+-- matched against any other MutateOther.
 similar :: MuVariant -> MuVariant -> Bool
-similar (MutateOther a) (MutateOther b) =
-    if
-        | null a -> True
-        | null b -> True
-        | otherwise -> a == b
+similar (MutateOther a) (MutateOther b) = if | null a  -> True
+                                             | null b -> True
+                                             | otherwise -> a == b
 similar x y = x == y

--- a/src/Test/Mendel/Config.hs
+++ b/src/Test/Mendel/Config.hs
@@ -1,0 +1,138 @@
+{-# LANGUAGE MultiWayIf #-}
+-- | Configuration module
+module Test.Mendel.Config where
+
+-- | The knob controlling if we want first order mutation.
+data GenerationMode
+  = FirstOrderOnly
+  | FirstAndHigherOrder
+  deriving (Eq, Show)
+
+-- | For function mutations, whether the function is a symbol or an identifier
+-- for example,`head` is an identifier while `==` is a symbol.
+data FnType = FnSymbol | FnIdent
+  deriving (Eq, Show)
+
+-- | User defined function groups. Indicate whether the functions are symbols
+-- or identifiers, and also the group of functions to interchange for.
+-- We dont allow mixing of identifiers and functions for now (harder to
+-- match)
+data FnOp = FnOp {_type :: FnType, _fns :: [String]}
+  deriving (Eq, Show)
+
+
+-- | predicates ["pred", "id", "succ"]
+predNums :: [String]
+predNums = ["pred", "id", "succ"]
+
+-- | functions on lists ["sum", "product", "maximum", "minimum", "head", "last"]
+arithLists :: [String]
+arithLists = ["sum", "product", "maximum", "minimum", "head", "last"]
+
+
+-- | comparison operators ["<", ">", "<=", ">=", "/=", "=="]
+comparators :: [String]
+comparators = ["<", ">", "<=", ">=", "/=", "=="]
+
+-- | binary arithmetic ["+", "-", "*", "/"]
+binAriths :: [String]
+binAriths = ["+", "-", "*", "/"]
+
+-- | The configuration options
+-- if 1 is provided, all mutants are selected for that kind, and 0 ensures that
+-- no mutants are picked for that kind. Any fraction in between causes that
+-- many mutants to be picked randomly from the available pool
+data Config = Config {
+-- | Mutation operators on operator or function replacement
+  muOp :: [FnOp]
+-- | Mutate pattern matches for functions?
+-- for example
+--
+-- > first [] = Nothing
+-- > first (x:_) = Just x
+--
+-- is mutated to
+--
+-- > first (x:_) = Just x
+-- > first [] = Nothing
+  , doMutatePatternMatches :: Rational
+-- | Mutates integer values by +1 or -1 or by replacing it with 0 or 1
+  , doMutateValues :: Rational
+-- | Mutates operators and functions, that is
+--
+-- > i + 1
+--
+-- becomes
+--
+-- > i - 1
+--
+-- > i * 1
+--
+-- > i / 1
+  , doMutateFunctions :: Rational
+-- | negate if conditions, that is
+--
+-- > if True then 1 else 0
+--
+-- becomes
+--
+-- > if True then 0 else 1
+  , doNegateIfElse :: Rational
+-- | negate guarded booleans in guarded definitions
+--
+-- > myFn x | x == 1 = True
+-- > myFn   | otherwise = False
+--
+-- becomes
+--
+-- > myFn x | not (x == 1) = True
+-- > myFn   | otherwise = False
+  , doNegateGuards :: Rational
+-- | Maximum number of mutants to generate.
+  , maxNumMutants :: Int
+-- | Generation mode, can be traditional (firstOrder) and
+-- higher order (higher order is experimental)
+  , genMode :: GenerationMode }
+  deriving Show
+
+-- | The default configuration
+defaultConfig :: Config
+defaultConfig = Config {
+    muOp = [
+      FnOp {_type=FnIdent, _fns= predNums},FnOp {_type=FnIdent, _fns= arithLists},
+      FnOp {_type=FnSymbol, _fns= comparators},FnOp {_type=FnSymbol, _fns=binAriths}]
+  , doMutatePatternMatches = 1.0
+  , doMutateValues = 1.0
+  , doMutateFunctions = 1.0
+  , doNegateIfElse = 1.0
+  , doNegateGuards = 1.0
+  , maxNumMutants = 300
+  , genMode = FirstOrderOnly }
+
+-- | Enumeration of different variants of mutations
+data MuVar = MutatePatternMatch
+           | MutateValues
+           | MutateFunctions
+           | MutateNegateIfElse
+           | MutateNegateGuards
+           | MutateOther String
+  deriving (Eq, Show)
+
+-- | getSample returns the fraction in config corresponding to the enum passed
+-- in
+getSample :: MuVar -> Config -> Rational
+getSample MutatePatternMatch c = doMutatePatternMatches c
+getSample MutateValues       c = doMutateValues c
+getSample MutateFunctions    c = doMutateFunctions c
+getSample MutateNegateIfElse c = doNegateIfElse c
+getSample MutateNegateGuards c = doNegateGuards c
+getSample MutateOther{} _c = 1
+
+-- | similarity between two mutation variants. For ease of use, MutateOther is
+-- treated differently. For MutateOther, if the string is empty, then it is
+-- matched against any other MutateOther.
+similar :: MuVar -> MuVar -> Bool
+similar (MutateOther a) (MutateOther b) = if | null a  -> True
+                                             | null b -> True
+                                             | otherwise -> a == b
+similar x y = x == y

--- a/src/Test/Mendel/Config.hs
+++ b/src/Test/Mendel/Config.hs
@@ -2,6 +2,8 @@
 -- | Configuration module
 module Test.Mendel.Config where
 
+import Test.Mendel.MutationVariant
+
 -- | The knob controlling if we want first order mutation.
 data GenerationMode
   = FirstOrderOnly
@@ -109,18 +111,9 @@ defaultConfig = Config {
   , maxNumMutants = 300
   , genMode = FirstOrderOnly }
 
--- | Enumeration of different variants of mutations
-data MuVar = MutatePatternMatch
-           | MutateValues
-           | MutateFunctions
-           | MutateNegateIfElse
-           | MutateNegateGuards
-           | MutateOther String
-  deriving (Eq, Show)
-
 -- | getSample returns the fraction in config corresponding to the enum passed
 -- in
-getSample :: MuVar -> Config -> Rational
+getSample :: MuVariant -> Config -> Rational
 getSample MutatePatternMatch c = doMutatePatternMatches c
 getSample MutateValues       c = doMutateValues c
 getSample MutateFunctions    c = doMutateFunctions c
@@ -131,7 +124,7 @@ getSample MutateOther{} _c = 1
 -- | similarity between two mutation variants. For ease of use, MutateOther is
 -- treated differently. For MutateOther, if the string is empty, then it is
 -- matched against any other MutateOther.
-similar :: MuVar -> MuVar -> Bool
+similar :: MuVariant -> MuVariant -> Bool
 similar (MutateOther a) (MutateOther b) = if | null a  -> True
                                              | null b -> True
                                              | otherwise -> a == b

--- a/src/Test/Mendel/Mutation.hs
+++ b/src/Test/Mendel/Mutation.hs
@@ -7,6 +7,17 @@ Description    : Apply mutation operators to Haskell modules
 
 This module provides the functionality to traverse Haskell modules and apply mutation operators.
 -}
+
+{-# LANGUAGE  TupleSections, RankNTypes #-}
+
+module Test.Mendel.Mutation (programMutants, 
+                             selectLitOps,
+                             --selectBLitOps,
+                             selectIfElseBoolNegOps,
+                             --selectGuardedBoolNegOps,
+                             --selectFnMatches
+                             ) where
+
 module Test.Mendel.Mutation (
     -- programMutants,
     selectLitOps,
@@ -28,10 +39,9 @@ import Data.List (nub, permutations, subsequences, (\\))
 import Data.Maybe (isJust)
 import Data.Typeable
 import GHC.Data.FastString qualified as GHC
-import GHC.Hs
-import GHC.Types.Basic qualified as GHC
-import GHC.Types.Name.Occurrence qualified as GHC
-import GHC.Types.Name.Reader qualified as GHC
+import GHC.Hs qualified as GHC
+import Language.Haskell.Syntax.Lit
+import Language.Haskell.Syntax.Expr
 import GHC.Types.SourceText
 import GHC.Types.SrcLoc qualified as GHC
 import Language.Haskell.Syntax.Expr

--- a/src/Test/Mendel/Mutation.hs
+++ b/src/Test/Mendel/Mutation.hs
@@ -20,6 +20,7 @@ import GHC.Types.SrcLoc qualified as GHC
 import Language.Haskell.Syntax.Expr qualified as Hs
 import Language.Haskell.Syntax.Lit qualified as Hs
 import Test.Mendel.MutationOperator (MuOp (..))
+import Test.Mendel.MutationVariant
 
 -------------------------------------------------------------------------------
 -- Mutation on Literals
@@ -76,7 +77,7 @@ gswapIfElse = mkT swapIfElse
 -------------------------------------------------------------------------------
 
 -- | Apply the given mutation operator to the Haskell module
-mutate :: MuOp -> GHC.HsModule GHC.GhcPs -> GHC.HsModule GHC.GhcPs
+mutate :: MuVariant -> GHC.HsModule GHC.GhcPs -> GHC.HsModule GHC.GhcPs
 mutate ReverseString = everywhere greverseStringLiteral
 mutate ReverseClausesInPatternMatch = everywhere greverseClauses
 mutate SwapPlusMinus = everywhere gswapPlusMinusOperator

--- a/src/Test/Mendel/Mutation.hs
+++ b/src/Test/Mendel/Mutation.hs
@@ -7,18 +7,6 @@ Description    : Apply mutation operators to Haskell modules
 
 This module provides the functionality to traverse Haskell modules and apply mutation operators.
 -}
-
-{-# LANGUAGE  TupleSections, RankNTypes #-}
-
-module Test.Mendel.Mutation (programMutants, 
-                             selectLitOps,
-                             --selectBLitOps,
-                             selectIfElseBoolNegOps,
-                             --selectGuardedBoolNegOps,
-                             --selectFnMatches,
-                             mutate'
-                             ) where
-
 module Test.Mendel.Mutation (
     -- programMutants,
     selectLitOps,
@@ -41,8 +29,9 @@ import Data.Maybe (isJust)
 import Data.Typeable
 import GHC.Data.FastString qualified as GHC
 import GHC.Hs
-import Language.Haskell.Syntax.Lit
-import Language.Haskell.Syntax.Expr
+import GHC.Types.Basic qualified as GHC
+import GHC.Types.Name.Occurrence qualified as GHC
+import GHC.Types.Name.Reader qualified as GHC
 import GHC.Types.SourceText
 import GHC.Types.SrcLoc qualified as GHC
 import Language.Haskell.Syntax.Expr

--- a/src/Test/Mendel/Mutation.hs
+++ b/src/Test/Mendel/Mutation.hs
@@ -12,7 +12,8 @@ module Test.Mendel.Mutation (programMutants,
                              --selectBLitOps,
                              selectIfElseBoolNegOps,
                              --selectGuardedBoolNegOps,
-                             --selectFnMatches
+                             --selectFnMatches,
+                             mutate'
                              ) where
 
 import Data.ByteString qualified as BS
@@ -341,8 +342,8 @@ gswapIfElse = mkT swapIfElse
 -------------------------------------------------------------------------------
 
 -- | Apply the given mutation operator to the Haskell module
-mutate :: MuVariant -> GHC.HsModule GHC.GhcPs -> GHC.HsModule GHC.GhcPs
-mutate ReverseString = everywhere greverseStringLiteral
-mutate ReverseClausesInPatternMatch = everywhere greverseClauses
-mutate SwapPlusMinus = everywhere gswapPlusMinusOperator
-mutate SwapIfElse = everywhere gswapIfElse
+mutate' :: MuVariant -> Module_ -> Module_
+mutate' ReverseString                = everywhere greverseStringLiteral
+mutate' ReverseClausesInPatternMatch = everywhere greverseClauses
+mutate' SwapPlusMinus                = everywhere gswapPlusMinusOperator
+mutate' SwapIfElse                   = everywhere gswapIfElse

--- a/src/Test/Mendel/Mutation.hs
+++ b/src/Test/Mendel/Mutation.hs
@@ -47,7 +47,6 @@ import Test.Mendel.MutationOperator (
     Module_,
     MuOp,
     Mutable,
-    Wrapped (..),
     getSpan,
     mkMpMuOp,
     same,
@@ -117,7 +116,7 @@ E.g.: if the operator is (op = "<" ==> ">") and there are two instances of
 "<" in the AST, then it will return two AST with each replaced.
 -}
 mutate :: (MuVariant, MuOp) -> (MuVariant, Span, Module_) -> [(MuVariant, Span, Module_)]
-mutate (v, op) (_v, _s, m) = map (v,getSpan op,) $ once (mkMpMuOp op) m \\ [m]
+mutate (v, op) (_v, _s, m) = undefined -- map (v,getSpan op,) $ once (mkMpMuOp op) m \\ [m]
 
 {- | Returns all mutation operators
 applicableOps ::

--- a/src/Test/Mendel/Mutation.hs
+++ b/src/Test/Mendel/Mutation.hs
@@ -1,121 +1,125 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TupleSections #-}
+
 {- |
 Module         : Test.Mendel.Mutation
 Description    : Apply mutation operators to Haskell modules
 
 This module provides the functionality to traverse Haskell modules and apply mutation operators.
 -}
+module Test.Mendel.Mutation (
+    -- programMutants,
+    selectLitOps,
+    -- selectBLitOps,
+    selectIfElseBoolNegOps,
+    -- selectGuardedBoolNegOps,
+    -- selectFnMatches,
+    mutate',
+) where
 
-{-# LANGUAGE  TupleSections, RankNTypes #-}
+-- GuardedRhs_,
 
-module Test.Mendel.Mutation (programMutants, 
-                             selectLitOps,
-                             --selectBLitOps,
-                             selectIfElseBoolNegOps,
-                             --selectGuardedBoolNegOps,
-                             --selectFnMatches,
-                             mutate'
-                             ) where
-
+import Control.Monad (MonadPlus, mplus)
 import Data.ByteString qualified as BS
+import Data.Generics (Data, GenericM, Typeable, gmapMo, listify, mkMp)
 import Data.Generics.Aliases (mkT)
 import Data.Generics.Schemes (everywhere)
+import Data.List (nub, permutations, subsequences, (\\))
+import Data.Maybe (isJust)
 import Data.Typeable
 import GHC.Data.FastString qualified as GHC
 import GHC.Hs
-import Language.Haskell.Syntax.Lit
-import Language.Haskell.Syntax.Expr
+import GHC.Types.Basic qualified as GHC
+import GHC.Types.Name.Occurrence qualified as GHC
+import GHC.Types.Name.Reader qualified as GHC
 import GHC.Types.SourceText
 import GHC.Types.SrcLoc qualified as GHC
-import GHC.Types.Basic qualified as GHC
-import GHC.Data.FastString qualified as GHC
-import GHC.Types.Name.Reader qualified as GHC
-import GHC.Types.Name.Occurrence qualified as GHC
-
-import Data.Generics.Schemes (everywhere)
-import Data.Generics.Aliases (mkT)
-import Data.ByteString qualified as BS
-import Data.Typeable
-
-import Data.List(nub, (\\), permutations, subsequences)
-
-import Test.Mendel.MutationOperator
-    ( (==>*),
-      getSpan,
-      mkMpMuOp,
-      same,
-      Decl_,
-      Exp_,
-      -- GuardedRhs_,
-      Literal_,
-      Module_,
-      MuOp,
-      Mutable,
-      Name_ )
-import Test.Mendel.Config
-    ( Config(muOp),
-      FnOp(_type, _fns),
-      FnType(FnSymbol, FnIdent))
-
-import Data.Generics (Data, GenericM, gmapMo, Typeable, mkMp, listify)
-import Control.Monad (MonadPlus, mplus)
-import Data.Maybe(isJust)
+import Language.Haskell.Syntax.Expr
+import Language.Haskell.Syntax.Lit
+import Test.Mendel.Config (
+    Config (muOp),
+    FnOp (_fns, _type),
+    FnType (FnIdent, FnSymbol),
+ )
+import Test.Mendel.MutationOperator (
+    Decl_ (..),
+    Exp_ (..),
+    Module_,
+    MuOp,
+    Mutable,
+    Wrapped (..),
+    getSpan,
+    mkMpMuOp,
+    same,
+    (==>*),
+ )
 import Test.Mendel.MutationVariant
-import GHC.Hs (HsLit(HsIntPrim))
 
 type Span = (Int, Int, Int, Int)
 
--- | apply a mutating function on a piece of code one at a time
--- like somewhere (from so)
-once :: MonadPlus m => GenericM m -> GenericM m
+{- | apply a mutating function on a piece of code one at a time
+like somewhere (from so)
+-}
+once :: (MonadPlus m) => GenericM m -> GenericM m
 once f x = f x `mplus` gmapMo (once f) x
 
--- | The function `relevantOps` does two filters. For the first, it
--- removes spurious transformations like "Int 1 ~~> Int 1". Secondly, it
--- tries to apply the transformation to the given program on some element
--- if it does not succeed, then we discard that transformation.
+{- | The function `relevantOps` does two filters. For the first, it
+removes spurious transformations like "Int 1 ~~> Int 1". Secondly, it
+tries to apply the transformation to the given program on some element
+if it does not succeed, then we discard that transformation.
+-}
 relevantOps :: (Data a, Eq a) => a -> [(MuVariant, MuOp)] -> [(MuVariant, MuOp)]
 relevantOps m oplst = filter (relevantOp m) $ filter (not . same . snd) oplst
-  -- check if an operator can be applied to a program
-  where relevantOp m' (_v, op) = isJust $ once (mkMpMuOp op) m'
+  where
+    -- check if an operator can be applied to a program
+    relevantOp m' (_v, op) = isJust $ once (mkMpMuOp op) m'
 
--- | convert a tuple with element and second array to an array of
--- tuples by repeating the first element 
+{- | convert a tuple with element and second array to an array of
+tuples by repeating the first element
+-}
 spread :: (a, [b]) -> [(a, b)]
-spread (a,lst) = map (a,) lst
+spread (a, lst) = map (a,) lst
 
 -- | The `choose` function generates subsets of a given size
 choose :: [a] -> Int -> [[a]]
 choose xs n = filter (\x -> length x == n) $ subsequences xs
 
--- | Produce all mutants after applying all operators
+{- | Produce all mutants after applying all operators
 programMutants ::
      Config                   -- ^ Configuration
   -> Module_                  -- ^ Module to mutate
   -> [(MuVariant, Span, Module_)] -- ^ Returns mutated modules
 programMutants config ast =  nub $ mutatesN (applicableOps config ast) ast fstOrder
   where fstOrder = 1 -- first order
+-}
 
--- | First and higher order mutation. The actual apply of mutation operators,
--- and generation of mutants happens here.
--- The third argument specifies whether it's first order or higher order
+{- | First and higher order mutation. The actual apply of mutation operators,
+and generation of mutants happens here.
+The third argument specifies whether it's first order or higher order
+-}
 mutatesN ::
-     [(MuVariant,MuOp)]     -- ^ Applicable Operators
-  -> Module_            -- ^ Module to mutate
-  -> Int                -- ^ Order of mutation (usually 1 - first order)
-  -> [(MuVariant, Span, Module_)] -- ^ Returns the mutated module
-mutatesN os ast = mutatesN' os (MutateOther [], (0,0,0,0), ast)
-  where mutatesN' ops ms 1 = concat [mutate op ms | op <- ops ]
-        mutatesN' ops ms c = concat [mutatesN' ops m 1 | m <- mutatesN' ops ms $ pred c]
+    -- | Applicable Operators
+    [(MuVariant, MuOp)] ->
+    -- | Module to mutate
+    Module_ ->
+    -- | Order of mutation (usually 1 - first order)
+    Int ->
+    -- | Returns the mutated module
+    [(MuVariant, Span, Module_)]
+mutatesN os ast = mutatesN' os (MutateOther [], (0, 0, 0, 0), ast)
+  where
+    mutatesN' ops ms 1 = concat [mutate op ms | op <- ops]
+    mutatesN' ops ms c = concat [mutatesN' ops m 1 | m <- mutatesN' ops ms $ pred c]
 
--- | Given a function, generate all mutants after applying applying
--- op once (op might be applied at different places).
--- E.g.: if the operator is (op = "<" ==> ">") and there are two instances of
--- "<" in the AST, then it will return two AST with each replaced.
+{- | Given a function, generate all mutants after applying applying
+op once (op might be applied at different places).
+E.g.: if the operator is (op = "<" ==> ">") and there are two instances of
+"<" in the AST, then it will return two AST with each replaced.
+-}
 mutate :: (MuVariant, MuOp) -> (MuVariant, Span, Module_) -> [(MuVariant, Span, Module_)]
-mutate (v, op) (_v, _s, m) = map (v, getSpan op, ) $ once (mkMpMuOp op) m \\ [m]
+mutate (v, op) (_v, _s, m) = map (v,getSpan op,) $ once (mkMpMuOp op) m \\ [m]
 
-
--- | Returns all mutation operators
+{- | Returns all mutation operators
 applicableOps ::
      Config                   -- ^ Configuration
   -> Module_                  -- ^ Module to mutate
@@ -126,137 +130,129 @@ applicableOps config ast = relevantOps ast opsList
             (MutateValues, selectLiteralOps ast),
             (MutateFunctions, selectFunctionOps (muOp config) ast),
             (MutateNegateIfElse, selectIfElseBoolNegOps ast)]
-            --(MutateNegateGuards, selectGuardedBoolNegOps ast)
+(MutateNegateGuards, selectGuardedBoolNegOps ast)
+-}
 
--- | For valops, we specify how any given literal value might
--- change. So we take a predicate specifying how to recognize the literal
--- value, a list of mappings specifying how the literal can change, and the
--- AST, and recurse over the AST looking for literals that match our predicate.
--- When we find any, we apply the given list of mappings to them, and produce
--- a MuOp mapping between the original value and transformed value. This list
--- of MuOp mappings are then returned.
-selectValOps :: (Typeable b, Mutable b) => (b -> Bool) -> (b -> [b]) -> Module_ -> [MuOp]
-selectValOps predicate f m = concat [ x ==>* f x |  x <- vals ]
-  where vals = listify predicate m
+{- | For valops, we specify how any given literal value might
+change. So we take a predicate specifying how to recognize the literal
+value, a list of mappings specifying how the literal can change, and the
+AST, and recurse over the AST looking for literals that match our predicate.
+When we find any, we apply the given list of mappings to them, and produce
+a MuOp mapping between the original value and transformed value. This list
+of MuOp mappings are then returned.
+-}
+selectValOps ::
+    (Typeable a, Typeable b, Mutable b) => (a -> Bool) -> (b -> [b]) -> Module_ -> [MuOp]
+selectValOps predicate f m = concat [x ==>* f x | x <- vals]
+  where
+    vals = map wrap $ listify predicate m
+    wrap = undefined
 
 -- | Look for literal values in AST, and return applicable MuOp transforms.
 selectLiteralOps :: Module_ -> [MuOp]
 selectLiteralOps m = selectLitOps m ++ selectBLitOps m
 
--- | Look for literal values in AST, and return applicable MuOp transforms.
--- Unfortunately booleans are not handled here.
+{- | Look for literal values in AST, and return applicable MuOp transforms.
+Unfortunately booleans are not handled here.
+-}
 selectLitOps :: Module_ -> [MuOp]
-selectLitOps = undefined --selectValOps isLit convert
-  where isLit :: Literal_ -> Bool
-        isLit HsInt{} = True
-        isLit HsIntPrim{} = True
-        isLit HsChar{} = True
-        isLit HsCharPrim{} = True
-        isLit HsFloatPrim{} = True
-        isLit HsDoublePrim{} = True
-        isLit HsString{} = True
-        isLit HsStringPrim{} = True
-        isLit HsWordPrim{} = True
-        isLit HsInteger{} = True
-        isLit HsRat{} = True
-        isLit HsInt64Prim{} = True
-        isLit HsWord64Prim{} = True
-        -- convert (HsInt l i) = map (apX (HsInt l i)) $ nub [i + 1, i - 1, 0, 1]
-        -- convert (HsIntPrim l i) = map (apX (HsIntPrim l i)) $ nub [i + 1, i - 1, 0, 1]
-        -- convert (HsChar l c) = map (apX (HsChar l)) [pred c, succ c]
-        -- convert (HsCharPrim l c) = map (apX (HsCharPrim l)) [pred c, succ c]
-        -- convert (HsFloatPrim l f) = map (apX (HsFloatPrim l)) $ nub [f + 1.0, f - 1.0, 0.0, 1.0]
-        -- convert (HsDoublePrim l f) = map (apX (HsDoublePrim l)) $ nub [f + 1.0, f - 1.0, 0.0, 1.0]
-        -- convert (HsString l _) = map (apX (HsString l)) $ nub [""]
-        -- convert (HsStringPrim l _) = map (apX (HsStringPrim l)) $ nub [""]
-        -- convert (HsWordPrim l i) = map (apX (HsWordPrim l)) $ nub [i + 1, i - 1, 0, 1]
-        apX :: (t1 -> [a] -> t) -> t1 -> t
-        apX fn i = fn i []
-        
+selectLitOps = undefined -- selectValOps isLit convert
+  where
+    isLit :: LHsExpr GhcPs -> Bool
+    isLit (GHC.L _ (HsLit _ (HsInt{}))) = True
+    isLit (GHC.L _ (HsLit _ (HsIntPrim{}))) = True
+    isLit (GHC.L _ (HsLit _ (HsChar{}))) = True
+    isLit (GHC.L _ (HsLit _ (HsCharPrim{}))) = True
+    isLit (GHC.L _ (HsLit _ (HsFloatPrim{}))) = True
+    isLit (GHC.L _ (HsLit _ (HsDoublePrim{}))) = True
+    isLit (GHC.L _ (HsLit _ (HsString{}))) = True
+    isLit (GHC.L _ (HsLit _ (HsStringPrim{}))) = True
+    isLit (GHC.L _ (HsLit _ (HsWordPrim{}))) = True
+    isLit (GHC.L _ (HsLit _ (HsInteger{}))) = True
+    isLit (GHC.L _ (HsLit _ (HsRat{}))) = True
+    isLit (GHC.L _ (HsLit _ (HsInt64Prim{}))) = True
+    isLit (GHC.L _ (HsLit _ (HsWord64Prim{}))) = True
+    isLit _ = False
+    -- convert (HsInt l i) = map (apX (HsInt l i)) $ nub [i + 1, i - 1, 0, 1]
+    -- convert (HsIntPrim l i) = map (apX (HsIntPrim l i)) $ nub [i + 1, i - 1, 0, 1]
+    -- convert (HsChar l c) = map (apX (HsChar l)) [pred c, succ c]
+    -- convert (HsCharPrim l c) = map (apX (HsCharPrim l)) [pred c, succ c]
+    -- convert (HsFloatPrim l f) = map (apX (HsFloatPrim l)) $ nub [f + 1.0, f - 1.0, 0.0, 1.0]
+    -- convert (HsDoublePrim l f) = map (apX (HsDoublePrim l)) $ nub [f + 1.0, f - 1.0, 0.0, 1.0]
+    -- convert (HsString l _) = map (apX (HsString l)) $ nub [""]
+    -- convert (HsStringPrim l _) = map (apX (HsStringPrim l)) $ nub [""]
+    -- convert (HsWordPrim l i) = map (apX (HsWordPrim l)) $ nub [i + 1, i - 1, 0, 1]
+    apX :: (t1 -> [a] -> t) -> t1 -> t
+    apX fn i = fn i []
 
--- | Convert Boolean Literals
---
--- > (True, False)
---
--- becomes
---
--- > (False, True)
+{- | Convert Boolean Literals
 
+> (True, False)
+
+becomes
+
+> (False, True)
+-}
 selectBLitOps :: Module_ -> [MuOp]
 selectBLitOps = selectValOps isLit convert
-  where isLit :: Name_ -> Bool
-        isLit n = GHC.occNameString n == "True" || GHC.occNameString n == "False" 
-        convert n | GHC.occNameString n == "True" = [GHC.mkVarOcc "False"]
-                  | GHC.occNameString n == "False" = [GHC.mkVarOcc "True"]
-                  | otherwise = error "Filter of Booleans doesn't work" 
+  where
+    isLit :: LHsExpr GhcPs -> Bool
+    isLit (GHC.L _ (HsVar _ (GHC.L _ (GHC.Unqual n)))) = GHC.occNameString n == "True" || GHC.occNameString n == "False"
+    isLit _ = False
+    convert (WrpExpr (GHC.L l1 (HsVar x (GHC.L l2 (GHC.Unqual n)))))
+        | GHC.occNameString n == "True" =
+            [WrpExpr (GHC.L l1 (HsVar x (GHC.L l2 (GHC.Unqual (GHC.mkVarOcc "False")))))]
+        | GHC.occNameString n == "False" =
+            [WrpExpr (GHC.L l1 (HsVar x (GHC.L l2 (GHC.Unqual (GHC.mkVarOcc "True")))))]
+        | otherwise = error "Filter of Booleans doesn't work"
+    convert _ = error "Filter of Booleans doesn't work"
 
--- | Negating boolean in if/else statements
---
--- > if True then 1 else 0
---
--- becomes
---
--- > if True then 0 else 1
+{- | Negating boolean in if/else statements
 
+> if True then 1 else 0
+
+becomes
+
+> if True then 0 else 1
+-}
 selectIfElseBoolNegOps :: Module_ -> [MuOp]
 selectIfElseBoolNegOps = selectValOps isIf convert
-  where isIf :: Exp_ -> Bool
-        isIf HsIf{} = True
-        isIf _    = False
-        convert (HsIf l e1 e2 e3) = [HsIf l e1 e3 e2]
-        convert _ = []
+  where
+    isIf :: LHsExpr GhcPs -> Bool
+    --
+    isIf (GHC.L _ (HsIf{})) = True
+    isIf _ = False
+    convert (WrpExpr (GHC.L l (HsIf s e1 e2 e3))) = [WrpExpr (GHC.L l (HsIf s e1 e3 e2))]
+    convert _ = []
 
--- | Negating boolean in Guards
--- | negate guarded booleans in guarded definitions
---
--- > myFn x | x == 1 = True
--- > myFn   | otherwise = False
---
--- becomes
---
--- > myFn x | not (x == 1) = True
--- > myFn   | otherwise = False
--- selectGuardedBoolNegOps :: Module_ -> [MuOp]
--- selectGuardedBoolNegOps = selectValOps isGuardedRhs convert
---   where isGuardedRhs :: GuardedRhs_ -> Bool
---         isGuardedRhs GuardedRhs{} = True
---         convert (GuardedRhs l stmts expr) = [GuardedRhs l s expr | s <- once (mkMp boolNegate) stmts]
---         boolNegate _e@(Qualifier _l (Var _lv (UnQual _lu (Ident _li "otherwise")))) = [] -- VERIFY
---         boolNegate (Qualifier l expr) = [Qualifier l (App l_ (Var l_ (UnQual l_ (Ident l_ "not"))) expr)]
---         boolNegate _x = [] -- VERIFY
+{- | Generate all operators for permuting and removal of pattern guards from
+function definitions
 
--- | dummy 
--- l_ :: SrcSpanInfo
--- l_ = SrcSpanInfo (SrcSpan "" 0 0 0 0) []
+> myFn (x:xs) = False
+> myFn _ = True
 
+becomes
 
--- | Generate all operators for permuting and removal of pattern guards from
--- function definitions
---
--- > myFn (x:xs) = False
--- > myFn _ = True
---
--- becomes
---
--- > myFn _ = True
--- > myFn (x:xs) = False
---
--- > myFn _ = True
---
--- > myFn (x:xs) = False
+> myFn _ = True
+> myFn (x:xs) = False
 
+> myFn _ = True
+
+> myFn (x:xs) = False
+-}
 selectFnMatches :: Module_ -> [MuOp]
 selectFnMatches = selectValOps isFunct convert
-   where isFunct :: Decl_ -> Bool
-         isFunct (ValD _ (FunBind {})) = True
-         isFunct _    = False
-         convert (ValD x (FunBind ext id mg)) = undefined--map (ValD x (FunBind ext id mg)) $ filter (/= ms) (permutations ms ++ removeOneElem ms)
-         convert _ = []
+  where
+    isFunct :: LHsDecl GhcPs -> Bool
+    isFunct (GHC.L _ (ValD _ (FunBind{}))) = True
+    isFunct _ = False
+    convert (WrpDecl (GHC.L l (ValD x (FunBind ext id mg)))) = undefined -- map (ValD x (FunBind ext id mg)) $ filter (/= ms) (permutations ms ++ removeOneElem ms)
+    convert _ = []
 
-
--- | Generate all operators for permuting symbols like binary operators
--- Since we are looking for symbols, we are reasonably sure that it is not
--- locally bound to a variable.
+{- | Generate all operators for permuting symbols like binary operators
+Since we are looking for symbols, we are reasonably sure that it is not
+locally bound to a variable.
+-}
 selectSymbolFnOps :: Module_ -> [String] -> [MuOp]
 selectSymbolFnOps m s = undefined -- selectValOps isBin convert m
 --   where isBin :: Name_ -> Bool
@@ -265,21 +261,25 @@ selectSymbolFnOps m s = undefined -- selectValOps isBin convert m
 --         convert (Symbol l n) = map (Symbol l) $ filter (/= n) s
 --         convert _ = []
 
--- | Generate all operators for permuting commonly used functions (with
--- identifiers).
+{- | Generate all operators for permuting commonly used functions (with
+identifiers).
+-}
 selectIdentFnOps :: Module_ -> [String] -> [MuOp]
-selectIdentFnOps m s = selectValOps isCommonFn convert m
-  where isCommonFn :: Exp_ -> Bool
-        isCommonFn (HsVar _ (GHC.L _ (GHC.Unqual n))) | GHC.occNameString n `elem` s = True
-        isCommonFn _ = False
-        convert (HsVar _ (GHC.L l (GHC.Unqual n))) = undefined --map  (HsVar lv_ . UnQual lu_ . Ident li_) $ filter (/= GHC.occNameString n) s
-        convert _ = []
+selectIdentFnOps m s = undefined -- selectValOps isCommonFn convert m
+  where
+    isCommonFn :: LHsExpr GhcPs -> Bool
+    isCommonFn (GHC.L _ (HsVar _ (GHC.L _ (GHC.Unqual n)))) | GHC.occNameString n `elem` s = True
+    isCommonFn _ = False
 
--- | Generate all operators depending on whether it is a symbol or not.
+--       convert (HsVar _ (GHC.L l (GHC.Unqual n))) = undefined --map  (HsVar lv_ . UnQual lu_ . Ident li_) $ filter (/= GHC.occNameString n) s
+--       convert _ = []
+
+{- | Generate all operators depending on whether it is a symbol or not.
 selectFunctionOps :: [FnOp] -> Module_ -> [MuOp]
 selectFunctionOps fo f = concatMap (selectIdentFnOps f) idents ++ concatMap (selectSymbolFnOps f) syms
   where idents = map _fns $ filter (\a -> _type a == FnIdent) fo
         syms = map _fns $ filter (\a -> _type a == FnSymbol) fo
+-}
 
 -- (Var l (UnQual l (Ident l "ab")))
 -- (App l (Var l (UnQual l (Ident l "head"))) (Var l (UnQual l (Ident l "b"))))
@@ -287,9 +287,10 @@ selectFunctionOps fo f = concatMap (selectIdentFnOps f) idents ++ concatMap (sel
 -- (InfixApp l (Var l (UnQual l (Ident l "a"))) (QVarOp l (UnQual l (Symbol l ">"))) (Var l (UnQual l (Ident l "b"))))
 -- (InfixApp l (Var l (UnQual l (Ident l "a"))) (QVarOp l (UnQual l (Ident l "x"))) (Var l (UnQual l (Ident l "b"))))
 
--- | Generate sub-arrays with one less element except when we have only
--- a single element.
-removeOneElem :: Eq t => [t] -> [[t]]
+{- | Generate sub-arrays with one less element except when we have only
+a single element.
+-}
+removeOneElem :: (Eq t) => [t] -> [[t]]
 removeOneElem [_] = []
 removeOneElem l = choose l (length l - 1)
 
@@ -348,7 +349,7 @@ gswapIfElse = mkT swapIfElse
 
 -- | Apply the given mutation operator to the Haskell module
 mutate' :: MuVariant -> Module_ -> Module_
-mutate' ReverseString                = everywhere greverseStringLiteral
+mutate' ReverseString = everywhere greverseStringLiteral
 mutate' ReverseClausesInPatternMatch = everywhere greverseClauses
-mutate' SwapPlusMinus                = everywhere gswapPlusMinusOperator
-mutate' SwapIfElse                   = everywhere gswapIfElse
+mutate' SwapPlusMinus = everywhere gswapPlusMinusOperator
+mutate' SwapIfElse = everywhere gswapIfElse

--- a/src/Test/Mendel/Mutation.hs
+++ b/src/Test/Mendel/Mutation.hs
@@ -4,7 +4,10 @@ Description    : Apply mutation operators to Haskell modules
 
 This module provides the functionality to traverse Haskell modules and apply mutation operators.
 -}
-module Test.Mendel.Mutation (mutate) where
+
+{-# LANGUAGE  TupleSections, RankNTypes #-}
+
+module Test.Mendel.Mutation (programMutants, selectLitOps, selectBLitOps, selectIfElseBoolNegOps, selectGuardedBoolNegOps, selectFnMatches) where
 
 import Data.ByteString qualified as BS
 import Data.Generics.Aliases (mkT)
@@ -12,14 +15,274 @@ import Data.Generics.Schemes (everywhere)
 import Data.Typeable
 import GHC.Data.FastString qualified as GHC
 import GHC.Hs qualified as GHC
-import GHC.Types.Basic qualified as GHC
-import GHC.Types.Name.Occurrence qualified as GHC
-import GHC.Types.Name.Reader qualified as GHC
+import Language.Haskell.Syntax.Lit
+import Language.Haskell.Syntax.Expr qualified as Hs
 import GHC.Types.SourceText
 import GHC.Types.SrcLoc qualified as GHC
-import Language.Haskell.Syntax.Expr qualified as Hs
-import Language.Haskell.Syntax.Lit qualified as Hs
-import Test.Mendel.MutationOperator (MuOp (..))
+import GHC.Types.Basic qualified as GHC
+import GHC.Data.FastString qualified as GHC
+import GHC.Types.Name.Reader qualified as GHC
+import GHC.Types.Name.Occurrence qualified as GHC
+
+import Data.Generics.Schemes (everywhere)
+import Data.Generics.Aliases (mkT)
+import Data.ByteString qualified as BS
+import Data.Typeable
+
+import Data.List(nub, (\\), permutations, subsequences)
+
+import Test.Mendel.MutationOperator
+    ( (==>*),
+      -- getSpan,
+      mkMpMuOp,
+      same,
+      Decl_,
+      Exp_,
+      -- GuardedRhs_,
+      Literal_,
+      Module_,
+      MuOp,
+      Mutable,
+      Name_ )
+import Test.Mendel.Config
+    ( Config(muOp),
+      FnOp(_type, _fns),
+      FnType(FnSymbol, FnIdent),
+      MuVar(..) )
+
+import Data.Generics (Data, GenericM, gmapMo, Typeable, mkMp, listify)
+import Control.Monad (MonadPlus, mplus)
+import Data.Maybe(isJust)
+import Test.Mendel.MutationVariant (MuVariant)
+import GHC.Hs (HsLit(HsIntPrim))
+
+type Span = (Int, Int, Int, Int)
+
+-- | apply a mutating function on a piece of code one at a time
+-- like somewhere (from so)
+once :: MonadPlus m => GenericM m -> GenericM m
+once f x = f x `mplus` gmapMo (once f) x
+
+-- | The function `relevantOps` does two filters. For the first, it
+-- removes spurious transformations like "Int 1 ~~> Int 1". Secondly, it
+-- tries to apply the transformation to the given program on some element
+-- if it does not succeed, then we discard that transformation.
+relevantOps :: (Data a, Eq a) => a -> [(MuVariant, MuOp)] -> [(MuVariant, MuOp)]
+relevantOps m oplst = filter (relevantOp m) $ filter (not . same . snd) oplst
+  -- check if an operator can be applied to a program
+  where relevantOp m' (_v, op) = isJust $ once (mkMpMuOp op) m'
+
+-- | convert a tuple with element and second array to an array of
+-- tuples by repeating the first element 
+spread :: (a, [b]) -> [(a, b)]
+spread (a,lst) = map (a,) lst
+
+-- | The `choose` function generates subsets of a given size
+choose :: [a] -> Int -> [[a]]
+choose xs n = filter (\x -> length x == n) $ subsequences xs
+
+-- | Produce all mutants after applying all operators
+programMutants ::
+     Config                   -- ^ Configuration
+  -> Module_                  -- ^ Module to mutate
+  -> [(MuVar, Span, Module_)] -- ^ Returns mutated modules
+programMutants config ast =  nub $ mutatesN (applicableOps config ast) ast fstOrder
+  where fstOrder = 1 -- first order
+
+-- | First and higher order mutation. The actual apply of mutation operators,
+-- and generation of mutants happens here.
+-- The third argument specifies whether it's first order or higher order
+mutatesN ::
+     [(MuVar,MuOp)]     -- ^ Applicable Operators
+  -> Module_            -- ^ Module to mutate
+  -> Int                -- ^ Order of mutation (usually 1 - first order)
+  -> [(MuVar, Span, Module_)] -- ^ Returns the mutated module
+mutatesN os ast = mutatesN' os (MutateOther [], (0,0,0,0), ast)
+  where mutatesN' ops ms 1 = concat [mutate op ms | op <- ops ]
+        mutatesN' ops ms c = concat [mutatesN' ops m 1 | m <- mutatesN' ops ms $ pred c]
+
+-- | Given a function, generate all mutants after applying applying
+-- op once (op might be applied at different places).
+-- E.g.: if the operator is (op = "<" ==> ">") and there are two instances of
+-- "<" in the AST, then it will return two AST with each replaced.
+mutate :: (MuVar, MuOp) -> (MuVar, Span, Module_) -> [(MuVar, Span, Module_)]
+mutate (v, op) (_v, _s, m) = map (v, getSpan op, ) $ once (mkMpMuOp op) m \\ [m]
+
+
+-- | Returns all mutation operators
+applicableOps ::
+     Config                   -- ^ Configuration
+  -> Module_                  -- ^ Module to mutate
+  -> [(MuVar,MuOp)]           -- ^ Returns mutation operators
+applicableOps config ast = relevantOps ast opsList
+  where opsList = concatMap spread [
+            (MutatePatternMatch, selectFnMatches ast),
+            (MutateValues, selectLiteralOps ast),
+            (MutateFunctions, selectFunctionOps (muOp config) ast),
+            (MutateNegateIfElse, selectIfElseBoolNegOps ast),
+            (MutateNegateGuards, selectGuardedBoolNegOps ast)]
+
+
+-- | For valops, we specify how any given literal value might
+-- change. So we take a predicate specifying how to recognize the literal
+-- value, a list of mappings specifying how the literal can change, and the
+-- AST, and recurse over the AST looking for literals that match our predicate.
+-- When we find any, we apply the given list of mappings to them, and produce
+-- a MuOp mapping between the original value and transformed value. This list
+-- of MuOp mappings are then returned.
+selectValOps :: (Typeable b, Mutable b) => (b -> Bool) -> (b -> [b]) -> Module_ -> [MuOp]
+selectValOps predicate f m = concat [ x ==>* f x |  x <- vals ]
+  where vals = listify predicate m
+
+-- | Look for literal values in AST, and return applicable MuOp transforms.
+selectLiteralOps :: Module_ -> [MuOp]
+selectLiteralOps m = selectLitOps m ++ selectBLitOps m
+
+-- | Look for literal values in AST, and return applicable MuOp transforms.
+-- Unfortunately booleans are not handled here.
+selectLitOps :: Module_ -> [MuOp]
+selectLitOps = selectValOps isLit convert
+  where isLit :: Literal_ -> Bool
+        isLit (HsInt _ _) = True
+        isLit (HsIntPrim _ _) = True
+        isLit (HsChar _ _) = True
+        isLit (HsCharPrim _ _) = True
+        isLit (HsFloatPrim _ _) = True
+        isLit (HsDoublePrim _ _) = True
+        isLit (HsString _ _) = True
+        isLit (HsStringPrim _ _) = True
+        isLit (HsWordPrim _ _) = True
+        convert (HsInt l i) = map (apX (HsInt l)) $ nub [i + 1, i - 1, 0, 1]
+        convert (HsIntPrim l i) = map (apX (HsIntPrim l)) $ nub [i + 1, i - 1, 0, 1]
+        convert (HsChar l c) = map (apX (HsChar l)) [pred c, succ c]
+        convert (HsCharPrim l c) = map (apX (HsCharPrim l)) [pred c, succ c]
+        convert (HsFloatPrim l f) = map (apX (HsFloatPrim l)) $ nub [f + 1.0, f - 1.0, 0.0, 1.0]
+        convert (HsDoublePrim l f) = map (apX (HsDoublePrim l)) $ nub [f + 1.0, f - 1.0, 0.0, 1.0]
+        convert (HsString l _) = map (apX (HsString l)) $ nub [""]
+        convert (HsStringPrim l _) = map (apX (HsStringPrim l)) $ nub [""]
+        convert (HsWordPrim l i) = map (apX (HsWordPrim l)) $ nub [i + 1, i - 1, 0, 1]
+        apX :: (t1 -> [a] -> t) -> t1 -> t
+        apX fn i = fn i []
+
+-- | Convert Boolean Literals
+--
+-- > (True, False)
+--
+-- becomes
+--
+-- > (False, True)
+
+selectBLitOps :: Module_ -> [MuOp]
+selectBLitOps = nverselectValOps isLit convert
+  where isLit :: Name_ -> Bool
+        isLit (Ident _l "True") = True
+        isLit (Ident _l "False") = True
+        isLit _ = False
+        convert (Ident l "True") = [Ident l "False"]
+        convert (Ident l "False") = [Ident l "True"]
+        convert _ = []
+
+-- | Negating boolean in if/else statements
+--
+-- > if True then 1 else 0
+--
+-- becomes
+--
+-- > if True then 0 else 1
+
+selectIfElseBoolNegOps :: Module_ -> [MuOp]
+selectIfElseBoolNegOps = selectValOps isIf convert
+  where isIf :: Exp_ -> Bool
+        isIf If{} = True
+        isIf _    = False
+        convert (If l e1 e2 e3) = [If l e1 e3 e2]
+        convert _ = []
+
+-- | Negating boolean in Guards
+-- | negate guarded booleans in guarded definitions
+--
+-- > myFn x | x == 1 = True
+-- > myFn   | otherwise = False
+--
+-- becomes
+--
+-- > myFn x | not (x == 1) = True
+-- > myFn   | otherwise = False
+selectGuardedBoolNegOps :: Module_ -> [MuOp]
+selectGuardedBoolNegOps = selectValOps isGuardedRhs convert
+  where isGuardedRhs :: GuardedRhs_ -> Bool
+        isGuardedRhs GuardedRhs{} = True
+        convert (GuardedRhs l stmts expr) = [GuardedRhs l s expr | s <- once (mkMp boolNegate) stmts]
+        boolNegate _e@(Qualifier _l (Var _lv (UnQual _lu (Ident _li "otherwise")))) = [] -- VERIFY
+        boolNegate (Qualifier l expr) = [Qualifier l (App l_ (Var l_ (UnQual l_ (Ident l_ "not"))) expr)]
+        boolNegate _x = [] -- VERIFY
+
+-- | dummy 
+l_ :: SrcSpanInfo
+l_ = SrcSpanInfo (SrcSpan "" 0 0 0 0) []
+
+
+-- | Generate all operators for permuting and removal of pattern guards from
+-- function definitions
+--
+-- > myFn (x:xs) = False
+-- > myFn _ = True
+--
+-- becomes
+--
+-- > myFn _ = True
+-- > myFn (x:xs) = False
+--
+-- > myFn _ = True
+--
+-- > myFn (x:xs) = False
+
+selectFnMatches :: Module_ -> [MuOp]
+selectFnMatches = selectValOps isFunct convert
+  where isFunct :: Decl_ -> Bool
+        isFunct FunBind{} = True
+        isFunct _    = False
+        convert (FunBind l ms) = map (FunBind l) $ filter (/= ms) (permutations ms ++ removeOneElem ms)
+        convert _ = []
+
+-- | Generate all operators for permuting symbols like binary operators
+-- Since we are looking for symbols, we are reasonably sure that it is not
+-- locally bound to a variable.
+selectSymbolFnOps :: Module_ -> [String] -> [MuOp]
+selectSymbolFnOps m s = selectValOps isBin convert m
+  where isBin :: Name_ -> Bool
+        isBin (Symbol _l n) | n `elem` s = True
+        isBin _ = False
+        convert (Symbol l n) = map (Symbol l) $ filter (/= n) s
+        convert _ = []
+
+-- | Generate all operators for permuting commonly used functions (with
+-- identifiers).
+selectIdentFnOps :: Module_ -> [String] ->  [MuOp]
+selectIdentFnOps m s = selectValOps isCommonFn convert m
+  where isCommonFn :: Exp_ -> Bool
+        isCommonFn (Var _lv (UnQual _lu (Ident _l n))) | n `elem` s = True
+        isCommonFn _ = False
+        convert (Var lv_ (UnQual lu_ (Ident li_ n))) = map  (Var lv_ . UnQual lu_ . Ident li_) $ filter (/= n) s
+        convert _ = []
+
+-- | Generate all operators depending on whether it is a symbol or not.
+selectFunctionOps :: [FnOp] -> Module_ -> [MuOp]
+selectFunctionOps fo f = concatMap (selectIdentFnOps f) idents ++ concatMap (selectSymbolFnOps f) syms
+  where idents = map _fns $ filter (\a -> _type a == FnIdent) fo
+        syms = map _fns $ filter (\a -> _type a == FnSymbol) fo
+
+-- (Var l (UnQual l (Ident l "ab")))
+-- (App l (Var l (UnQual l (Ident l "head"))) (Var l (UnQual l (Ident l "b"))))
+-- (App l (App l (Var l (UnQual l (Ident l "head"))) (Var l (UnQual l (Ident l "a")))) (Var l (UnQual l (Ident l "b")))))
+-- (InfixApp l (Var l (UnQual l (Ident l "a"))) (QVarOp l (UnQual l (Symbol l ">"))) (Var l (UnQual l (Ident l "b"))))
+-- (InfixApp l (Var l (UnQual l (Ident l "a"))) (QVarOp l (UnQual l (Ident l "x"))) (Var l (UnQual l (Ident l "b"))))
+
+-- | Generate sub-arrays with one less element except when we have only
+-- a single element.
+removeOneElem :: Eq t => [t] -> [[t]]
+removeOneElem [_] = []
+removeOneElem l = choose l (length l - 1)
 
 -------------------------------------------------------------------------------
 -- Mutation on Literals
@@ -76,8 +339,7 @@ gswapIfElse = mkT swapIfElse
 -------------------------------------------------------------------------------
 
 -- | Apply the given mutation operator to the Haskell module
-mutate :: MuOp -> GHC.HsModule GHC.GhcPs -> GHC.HsModule GHC.GhcPs
-mutate ReverseString = everywhere greverseStringLiteral
-mutate ReverseClausesInPatternMatch = everywhere greverseClauses
-mutate SwapPlusMinus = everywhere gswapPlusMinusOperator
-mutate SwapIfElse = everywhere gswapIfElse
+-- mutate :: MuVariant -> Module_ -> Module_
+-- mutate ReverseString                = everywhere greverseStringLiteral
+-- mutate ReverseClausesInPatternMatch = everywhere greverseClauses
+-- mutate SwapPlusMinus                = everywhere gswapPlusMinusOperator

--- a/src/Test/Mendel/Mutation.hs
+++ b/src/Test/Mendel/Mutation.hs
@@ -12,7 +12,8 @@ module Test.Mendel.Mutation (programMutants,
                              --selectBLitOps,
                              selectIfElseBoolNegOps,
                              --selectGuardedBoolNegOps,
-                             --selectFnMatches
+                             --selectFnMatches,
+                             mutate'
                              ) where
 
 import Data.ByteString qualified as BS
@@ -341,7 +342,8 @@ gswapIfElse = mkT swapIfElse
 -------------------------------------------------------------------------------
 
 -- | Apply the given mutation operator to the Haskell module
--- mutate :: MuVariant -> Module_ -> Module_
--- mutate ReverseString                = everywhere greverseStringLiteral
--- mutate ReverseClausesInPatternMatch = everywhere greverseClauses
--- mutate SwapPlusMinus                = everywhere gswapPlusMinusOperator
+mutate' :: MuVariant -> Module_ -> Module_
+mutate' ReverseString                = everywhere greverseStringLiteral
+mutate' ReverseClausesInPatternMatch = everywhere greverseClauses
+mutate' SwapPlusMinus                = everywhere gswapPlusMinusOperator
+mutate' SwapIfElse                   = everywhere gswapIfElse

--- a/src/Test/Mendel/Mutation.hs
+++ b/src/Test/Mendel/Mutation.hs
@@ -4,7 +4,10 @@ Description    : Apply mutation operators to Haskell modules
 
 This module provides the functionality to traverse Haskell modules and apply mutation operators.
 -}
-module Test.Mendel.Mutation (mutate) where
+
+{-# LANGUAGE  TupleSections, RankNTypes #-}
+
+module Test.Mendel.Mutation (programMutants, selectLitOps, selectBLitOps, selectIfElseBoolNegOps, selectGuardedBoolNegOps, selectFnMatches) where
 
 import Data.ByteString qualified as BS
 import Data.Generics.Aliases (mkT)
@@ -12,15 +15,274 @@ import Data.Generics.Schemes (everywhere)
 import Data.Typeable
 import GHC.Data.FastString qualified as GHC
 import GHC.Hs qualified as GHC
-import GHC.Types.Basic qualified as GHC
-import GHC.Types.Name.Occurrence qualified as GHC
-import GHC.Types.Name.Reader qualified as GHC
+import Language.Haskell.Syntax.Lit
+import Language.Haskell.Syntax.Expr qualified as Hs
 import GHC.Types.SourceText
 import GHC.Types.SrcLoc qualified as GHC
-import Language.Haskell.Syntax.Expr qualified as Hs
-import Language.Haskell.Syntax.Lit qualified as Hs
-import Test.Mendel.MutationOperator (MuOp (..))
-import Test.Mendel.MutationVariant
+import GHC.Types.Basic qualified as GHC
+import GHC.Data.FastString qualified as GHC
+import GHC.Types.Name.Reader qualified as GHC
+import GHC.Types.Name.Occurrence qualified as GHC
+
+import Data.Generics.Schemes (everywhere)
+import Data.Generics.Aliases (mkT)
+import Data.ByteString qualified as BS
+import Data.Typeable
+
+import Data.List(nub, (\\), permutations, subsequences)
+
+import Test.Mendel.MutationOperator
+    ( (==>*),
+      -- getSpan,
+      mkMpMuOp,
+      same,
+      Decl_,
+      Exp_,
+      -- GuardedRhs_,
+      Literal_,
+      Module_,
+      MuOp,
+      Mutable,
+      Name_ )
+import Test.Mendel.Config
+    ( Config(muOp),
+      FnOp(_type, _fns),
+      FnType(FnSymbol, FnIdent),
+      MuVar(..) )
+
+import Data.Generics (Data, GenericM, gmapMo, Typeable, mkMp, listify)
+import Control.Monad (MonadPlus, mplus)
+import Data.Maybe(isJust)
+import Test.Mendel.MutationVariant (MuVariant)
+import GHC.Hs (HsLit(HsIntPrim))
+
+type Span = (Int, Int, Int, Int)
+
+-- | apply a mutating function on a piece of code one at a time
+-- like somewhere (from so)
+once :: MonadPlus m => GenericM m -> GenericM m
+once f x = f x `mplus` gmapMo (once f) x
+
+-- | The function `relevantOps` does two filters. For the first, it
+-- removes spurious transformations like "Int 1 ~~> Int 1". Secondly, it
+-- tries to apply the transformation to the given program on some element
+-- if it does not succeed, then we discard that transformation.
+relevantOps :: (Data a, Eq a) => a -> [(MuVariant, MuOp)] -> [(MuVariant, MuOp)]
+relevantOps m oplst = filter (relevantOp m) $ filter (not . same . snd) oplst
+  -- check if an operator can be applied to a program
+  where relevantOp m' (_v, op) = isJust $ once (mkMpMuOp op) m'
+
+-- | convert a tuple with element and second array to an array of
+-- tuples by repeating the first element 
+spread :: (a, [b]) -> [(a, b)]
+spread (a,lst) = map (a,) lst
+
+-- | The `choose` function generates subsets of a given size
+choose :: [a] -> Int -> [[a]]
+choose xs n = filter (\x -> length x == n) $ subsequences xs
+
+-- | Produce all mutants after applying all operators
+programMutants ::
+     Config                   -- ^ Configuration
+  -> Module_                  -- ^ Module to mutate
+  -> [(MuVar, Span, Module_)] -- ^ Returns mutated modules
+programMutants config ast =  nub $ mutatesN (applicableOps config ast) ast fstOrder
+  where fstOrder = 1 -- first order
+
+-- | First and higher order mutation. The actual apply of mutation operators,
+-- and generation of mutants happens here.
+-- The third argument specifies whether it's first order or higher order
+mutatesN ::
+     [(MuVar,MuOp)]     -- ^ Applicable Operators
+  -> Module_            -- ^ Module to mutate
+  -> Int                -- ^ Order of mutation (usually 1 - first order)
+  -> [(MuVar, Span, Module_)] -- ^ Returns the mutated module
+mutatesN os ast = mutatesN' os (MutateOther [], (0,0,0,0), ast)
+  where mutatesN' ops ms 1 = concat [mutate op ms | op <- ops ]
+        mutatesN' ops ms c = concat [mutatesN' ops m 1 | m <- mutatesN' ops ms $ pred c]
+
+-- | Given a function, generate all mutants after applying applying
+-- op once (op might be applied at different places).
+-- E.g.: if the operator is (op = "<" ==> ">") and there are two instances of
+-- "<" in the AST, then it will return two AST with each replaced.
+mutate :: (MuVar, MuOp) -> (MuVar, Span, Module_) -> [(MuVar, Span, Module_)]
+mutate (v, op) (_v, _s, m) = map (v, getSpan op, ) $ once (mkMpMuOp op) m \\ [m]
+
+
+-- | Returns all mutation operators
+applicableOps ::
+     Config                   -- ^ Configuration
+  -> Module_                  -- ^ Module to mutate
+  -> [(MuVar,MuOp)]           -- ^ Returns mutation operators
+applicableOps config ast = relevantOps ast opsList
+  where opsList = concatMap spread [
+            (MutatePatternMatch, selectFnMatches ast),
+            (MutateValues, selectLiteralOps ast),
+            (MutateFunctions, selectFunctionOps (muOp config) ast),
+            (MutateNegateIfElse, selectIfElseBoolNegOps ast),
+            (MutateNegateGuards, selectGuardedBoolNegOps ast)]
+
+
+-- | For valops, we specify how any given literal value might
+-- change. So we take a predicate specifying how to recognize the literal
+-- value, a list of mappings specifying how the literal can change, and the
+-- AST, and recurse over the AST looking for literals that match our predicate.
+-- When we find any, we apply the given list of mappings to them, and produce
+-- a MuOp mapping between the original value and transformed value. This list
+-- of MuOp mappings are then returned.
+selectValOps :: (Typeable b, Mutable b) => (b -> Bool) -> (b -> [b]) -> Module_ -> [MuOp]
+selectValOps predicate f m = concat [ x ==>* f x |  x <- vals ]
+  where vals = listify predicate m
+
+-- | Look for literal values in AST, and return applicable MuOp transforms.
+selectLiteralOps :: Module_ -> [MuOp]
+selectLiteralOps m = selectLitOps m ++ selectBLitOps m
+
+-- | Look for literal values in AST, and return applicable MuOp transforms.
+-- Unfortunately booleans are not handled here.
+selectLitOps :: Module_ -> [MuOp]
+selectLitOps = selectValOps isLit convert
+  where isLit :: Literal_ -> Bool
+        isLit (HsInt _ _) = True
+        isLit (HsIntPrim _ _) = True
+        isLit (HsChar _ _) = True
+        isLit (HsCharPrim _ _) = True
+        isLit (HsFloatPrim _ _) = True
+        isLit (HsDoublePrim _ _) = True
+        isLit (HsString _ _) = True
+        isLit (HsStringPrim _ _) = True
+        isLit (HsWordPrim _ _) = True
+        convert (HsInt l i) = map (apX (HsInt l)) $ nub [i + 1, i - 1, 0, 1]
+        convert (HsIntPrim l i) = map (apX (HsIntPrim l)) $ nub [i + 1, i - 1, 0, 1]
+        convert (HsChar l c) = map (apX (HsChar l)) [pred c, succ c]
+        convert (HsCharPrim l c) = map (apX (HsCharPrim l)) [pred c, succ c]
+        convert (HsFloatPrim l f) = map (apX (HsFloatPrim l)) $ nub [f + 1.0, f - 1.0, 0.0, 1.0]
+        convert (HsDoublePrim l f) = map (apX (HsDoublePrim l)) $ nub [f + 1.0, f - 1.0, 0.0, 1.0]
+        convert (HsString l _) = map (apX (HsString l)) $ nub [""]
+        convert (HsStringPrim l _) = map (apX (HsStringPrim l)) $ nub [""]
+        convert (HsWordPrim l i) = map (apX (HsWordPrim l)) $ nub [i + 1, i - 1, 0, 1]
+        apX :: (t1 -> [a] -> t) -> t1 -> t
+        apX fn i = fn i []
+
+-- | Convert Boolean Literals
+--
+-- > (True, False)
+--
+-- becomes
+--
+-- > (False, True)
+
+selectBLitOps :: Module_ -> [MuOp]
+selectBLitOps = nverselectValOps isLit convert
+  where isLit :: Name_ -> Bool
+        isLit (Ident _l "True") = True
+        isLit (Ident _l "False") = True
+        isLit _ = False
+        convert (Ident l "True") = [Ident l "False"]
+        convert (Ident l "False") = [Ident l "True"]
+        convert _ = []
+
+-- | Negating boolean in if/else statements
+--
+-- > if True then 1 else 0
+--
+-- becomes
+--
+-- > if True then 0 else 1
+
+selectIfElseBoolNegOps :: Module_ -> [MuOp]
+selectIfElseBoolNegOps = selectValOps isIf convert
+  where isIf :: Exp_ -> Bool
+        isIf If{} = True
+        isIf _    = False
+        convert (If l e1 e2 e3) = [If l e1 e3 e2]
+        convert _ = []
+
+-- | Negating boolean in Guards
+-- | negate guarded booleans in guarded definitions
+--
+-- > myFn x | x == 1 = True
+-- > myFn   | otherwise = False
+--
+-- becomes
+--
+-- > myFn x | not (x == 1) = True
+-- > myFn   | otherwise = False
+selectGuardedBoolNegOps :: Module_ -> [MuOp]
+selectGuardedBoolNegOps = selectValOps isGuardedRhs convert
+  where isGuardedRhs :: GuardedRhs_ -> Bool
+        isGuardedRhs GuardedRhs{} = True
+        convert (GuardedRhs l stmts expr) = [GuardedRhs l s expr | s <- once (mkMp boolNegate) stmts]
+        boolNegate _e@(Qualifier _l (Var _lv (UnQual _lu (Ident _li "otherwise")))) = [] -- VERIFY
+        boolNegate (Qualifier l expr) = [Qualifier l (App l_ (Var l_ (UnQual l_ (Ident l_ "not"))) expr)]
+        boolNegate _x = [] -- VERIFY
+
+-- | dummy 
+l_ :: SrcSpanInfo
+l_ = SrcSpanInfo (SrcSpan "" 0 0 0 0) []
+
+
+-- | Generate all operators for permuting and removal of pattern guards from
+-- function definitions
+--
+-- > myFn (x:xs) = False
+-- > myFn _ = True
+--
+-- becomes
+--
+-- > myFn _ = True
+-- > myFn (x:xs) = False
+--
+-- > myFn _ = True
+--
+-- > myFn (x:xs) = False
+
+selectFnMatches :: Module_ -> [MuOp]
+selectFnMatches = selectValOps isFunct convert
+  where isFunct :: Decl_ -> Bool
+        isFunct FunBind{} = True
+        isFunct _    = False
+        convert (FunBind l ms) = map (FunBind l) $ filter (/= ms) (permutations ms ++ removeOneElem ms)
+        convert _ = []
+
+-- | Generate all operators for permuting symbols like binary operators
+-- Since we are looking for symbols, we are reasonably sure that it is not
+-- locally bound to a variable.
+selectSymbolFnOps :: Module_ -> [String] -> [MuOp]
+selectSymbolFnOps m s = selectValOps isBin convert m
+  where isBin :: Name_ -> Bool
+        isBin (Symbol _l n) | n `elem` s = True
+        isBin _ = False
+        convert (Symbol l n) = map (Symbol l) $ filter (/= n) s
+        convert _ = []
+
+-- | Generate all operators for permuting commonly used functions (with
+-- identifiers).
+selectIdentFnOps :: Module_ -> [String] ->  [MuOp]
+selectIdentFnOps m s = selectValOps isCommonFn convert m
+  where isCommonFn :: Exp_ -> Bool
+        isCommonFn (Var _lv (UnQual _lu (Ident _l n))) | n `elem` s = True
+        isCommonFn _ = False
+        convert (Var lv_ (UnQual lu_ (Ident li_ n))) = map  (Var lv_ . UnQual lu_ . Ident li_) $ filter (/= n) s
+        convert _ = []
+
+-- | Generate all operators depending on whether it is a symbol or not.
+selectFunctionOps :: [FnOp] -> Module_ -> [MuOp]
+selectFunctionOps fo f = concatMap (selectIdentFnOps f) idents ++ concatMap (selectSymbolFnOps f) syms
+  where idents = map _fns $ filter (\a -> _type a == FnIdent) fo
+        syms = map _fns $ filter (\a -> _type a == FnSymbol) fo
+
+-- (Var l (UnQual l (Ident l "ab")))
+-- (App l (Var l (UnQual l (Ident l "head"))) (Var l (UnQual l (Ident l "b"))))
+-- (App l (App l (Var l (UnQual l (Ident l "head"))) (Var l (UnQual l (Ident l "a")))) (Var l (UnQual l (Ident l "b")))))
+-- (InfixApp l (Var l (UnQual l (Ident l "a"))) (QVarOp l (UnQual l (Symbol l ">"))) (Var l (UnQual l (Ident l "b"))))
+-- (InfixApp l (Var l (UnQual l (Ident l "a"))) (QVarOp l (UnQual l (Ident l "x"))) (Var l (UnQual l (Ident l "b"))))
+
+-- | Generate sub-arrays with one less element except when we have only
+-- a single element.
+removeOneElem :: Eq t => [t] -> [[t]]
+removeOneElem [_] = []
+removeOneElem l = choose l (length l - 1)
 
 -------------------------------------------------------------------------------
 -- Mutation on Literals

--- a/src/Test/Mendel/Mutation.hs
+++ b/src/Test/Mendel/Mutation.hs
@@ -40,7 +40,7 @@ import Data.List (nub, permutations, subsequences, (\\))
 import Data.Maybe (isJust)
 import Data.Typeable
 import GHC.Data.FastString qualified as GHC
-import GHC.Hs qualified as GHC
+import GHC.Hs
 import Language.Haskell.Syntax.Lit
 import Language.Haskell.Syntax.Expr
 import GHC.Types.SourceText

--- a/src/Test/Mendel/Mutation.hs
+++ b/src/Test/Mendel/Mutation.hs
@@ -15,7 +15,8 @@ module Test.Mendel.Mutation (programMutants,
                              --selectBLitOps,
                              selectIfElseBoolNegOps,
                              --selectGuardedBoolNegOps,
-                             --selectFnMatches
+                             --selectFnMatches,
+                             mutate'
                              ) where
 
 module Test.Mendel.Mutation (

--- a/src/Test/Mendel/MutationOperator.hs
+++ b/src/Test/Mendel/MutationOperator.hs
@@ -13,7 +13,7 @@ module Test.Mendel.MutationOperator (MuOp
           , Decl_
           , Literal_
          -- , GuardedRhs_
-         --, getSpan
+         , getSpan
           ) where
 
 import qualified Data.Generics as G
@@ -35,6 +35,9 @@ type Decl_ = HsDecl GhcPs
 type Literal_ = HsLit GhcPs
 -- type GuardedRhs_ = GRHS GhcPs (LocatedA GhcPs) 
 
+instance Eq Module_ where
+  (==) x y = toConstr x == toConstr y
+
 instance Eq Exp_ where
   (==) x y = toConstr x == toConstr y
 
@@ -53,8 +56,8 @@ data MuOp = N  (Name_, Name_)
 
 -- How do I get the Annotated (a SrcSpanInfo) on apply's signature?
 -- | getSpan retrieve the span as a tuple
--- getSpan :: MuOp -> (Int, Int, Int, Int)
--- getSpan m = (startLine, startCol, endLine, endCol)
+getSpan :: MuOp -> (Int, Int, Int, Int)
+getSpan m = undefined --(startLine, startCol, endLine, endCol)
 --   where (endLine, endCol) = srcSpanEnd lspan
 --         (startLine, startCol) = srcSpanStart lspan
 --         getSpan' (N  (a,_)) = ann a

--- a/src/Test/Mendel/MutationOperator.hs
+++ b/src/Test/Mendel/MutationOperator.hs
@@ -8,6 +8,7 @@ module Test.Mendel.MutationOperator (MuOp
           , mkMpMuOp
           , same
           , Module_
+          , Name_
           , Exp_
           , Decl_
           , Literal_
@@ -52,16 +53,16 @@ data MuOp = N  (Name_, Name_)
 
 -- How do I get the Annotated (a SrcSpanInfo) on apply's signature?
 -- | getSpan retrieve the span as a tuple
-getSpan :: MuOp -> (Int, Int, Int, Int)
-getSpan m = (startLine, startCol, endLine, endCol)
-  where (endLine, endCol) = srcSpanEnd lspan
-        (startLine, startCol) = srcSpanStart lspan
-        getSpan' (N  (a,_)) = ann a
-        getSpan' (E  (a,_)) = ann a
-        getSpan' (D  (a,_)) = ann a
-        getSpan' (L  (a,_)) = ann a
-        -- getSpan' (G  (a,_)) = ann a
-        lspan = srcInfoSpan $ getSpan' m
+-- getSpan :: MuOp -> (Int, Int, Int, Int)
+-- getSpan m = (startLine, startCol, endLine, endCol)
+--   where (endLine, endCol) = srcSpanEnd lspan
+--         (startLine, startCol) = srcSpanStart lspan
+--         getSpan' (N  (a,_)) = ann a
+--         getSpan' (E  (a,_)) = ann a
+--         getSpan' (D  (a,_)) = ann a
+--         getSpan' (L  (a,_)) = ann a
+--         -- getSpan' (G  (a,_)) = ann a
+--         lspan = srcInfoSpan $ getSpan' m
 
 -- | The function `same` applies on a `MuOP` determining if transformation is
 -- between same values.
@@ -81,7 +82,7 @@ mkMpMuOp (L (x,y)) = G.mkMp (x ~~> y)
 -- mkMpMuOp (G (x,y)) = G.mkMp (x ~~> y) 
 
 -- | Show a specified mutation
-showM :: (Ppr a, Ppr a1) => (a, a1) -> String
+showM :: (Outputable a, Outputable a1) => (a, a1) -> String
 showM (s, t) = "{\n" ++ showPprUnsafe s ++ "\n} ==> {\n" ++ showPprUnsafe t ++ "\n}"
 
 -- | MuOp instance for Show

--- a/src/Test/Mendel/MutationOperator.hs
+++ b/src/Test/Mendel/MutationOperator.hs
@@ -1,18 +1,133 @@
-{- |
-Module         : Test.Mendel.MutationOperator
-Description    : Definition of mutation operators
+{-#  LANGUAGE Rank2Types, FlexibleInstances, ConstraintKinds #-}
+-- | Mutation operators
+module Test.Mendel.MutationOperator (MuOp
+          , Mutable(..)
+          , (==>*)
+          , (*==>*)
+          , (~~>)
+          , mkMpMuOp
+          , same
+          , Module_
+          , Exp_
+          , Decl_
+          , Literal_
+         -- , GuardedRhs_
+         --, getSpan
+          ) where
 
-This module provides various mutation operators which can be used
-to inject faults into Haskell modules.
--}
-module Test.Mendel.MutationOperator (MuOp (..)) where
+import qualified Data.Generics as G
+import Control.Monad (MonadPlus, mzero)
 
-{- | A mutation operator which describes a semantic change that should be applied to
-a Haskell module.
--}
-data MuOp
-    = ReverseString
-    | ReverseClausesInPatternMatch
-    | SwapPlusMinus
-    | SwapIfElse
-    deriving (Show, Eq)
+import GHC.Hs --(HsModule, HsExpr, HsDecl, HsLit, GhcPs)
+import GHC.Types.Name.Occurrence (OccName, occNameString)
+import Language.Haskell.Syntax.Expr (GRHS)
+import GHC.Parser.Annotation
+import Language.Haskell.TH.Ppr
+import Data.Data (Data(toConstr))
+import GHC.Utils.Outputable
+
+
+type Module_ = HsModule GhcPs
+type Name_ = OccName
+type Exp_ = HsExpr GhcPs
+type Decl_ = HsDecl GhcPs
+type Literal_ = HsLit GhcPs
+-- type GuardedRhs_ = GRHS GhcPs (LocatedA GhcPs) 
+
+instance Eq Exp_ where
+  (==) x y = toConstr x == toConstr y
+
+instance Eq Decl_ where
+  (==) x y = toConstr x == toConstr y
+
+
+-- | MuOp constructor used to specify mutation transformation
+data MuOp = N  (Name_, Name_)
+          | E  (Exp_, Exp_)
+          | D  (Decl_, Decl_)
+          | L  (Literal_, Literal_)
+         -- | G  (GuardedRhs_, GuardedRhs_)
+  deriving Eq
+
+
+-- How do I get the Annotated (a SrcSpanInfo) on apply's signature?
+-- | getSpan retrieve the span as a tuple
+getSpan :: MuOp -> (Int, Int, Int, Int)
+getSpan m = (startLine, startCol, endLine, endCol)
+  where (endLine, endCol) = srcSpanEnd lspan
+        (startLine, startCol) = srcSpanStart lspan
+        getSpan' (N  (a,_)) = ann a
+        getSpan' (E  (a,_)) = ann a
+        getSpan' (D  (a,_)) = ann a
+        getSpan' (L  (a,_)) = ann a
+        -- getSpan' (G  (a,_)) = ann a
+        lspan = srcInfoSpan $ getSpan' m
+
+-- | The function `same` applies on a `MuOP` determining if transformation is
+-- between same values.
+same :: MuOp -> Bool
+same (N (x,y)) = x == y
+same (E (x,y)) = x == y
+same (D (x,y)) = x == y
+same (L (x,y)) = x == y
+-- same (G (x,y)) = x == y
+
+-- | A wrapper over mkMp
+mkMpMuOp :: (MonadPlus m, G.Typeable a) => MuOp -> a -> m a
+mkMpMuOp (N (x,y)) = G.mkMp (x ~~> y) 
+mkMpMuOp (E (x,y)) = G.mkMp (x ~~> y) 
+mkMpMuOp (D (x,y)) = G.mkMp (x ~~> y) 
+mkMpMuOp (L (x,y)) = G.mkMp (x ~~> y) 
+-- mkMpMuOp (G (x,y)) = G.mkMp (x ~~> y) 
+
+-- | Show a specified mutation
+showM :: (Ppr a, Ppr a1) => (a, a1) -> String
+showM (s, t) = "{\n" ++ showPprUnsafe s ++ "\n} ==> {\n" ++ showPprUnsafe t ++ "\n}"
+
+-- | MuOp instance for Show
+instance Show MuOp where
+  show (N m) = showM m
+  show (E m) = showM m
+  show (D m) = showM m
+  show (L m) = showM m
+  -- show (G p) = showM p
+
+-- | Mutation operation representing translation from one fn to another fn.
+class Mutable a where
+  (==>) :: a -> a -> MuOp
+
+-- | The function `==>*` pairs up the given element with all elements of the
+-- second list, and applies `==>` on them.
+(==>*) :: Mutable a => a -> [a] -> [MuOp]
+(==>*) x = map (x ==>)
+
+-- | The function `*==>*` pairs up all elements of first list with all elements
+-- of second list and applies `==>` between them.
+(*==>*) :: Mutable a => [a] -> [a] -> [MuOp]
+xs *==>* ys = concatMap (==>* ys) xs
+
+-- | The function `~~>` accepts two values, and returns a function
+-- that if given a value equal to first, returns second
+-- we handle x ~~> x separately
+(~~>) :: (MonadPlus m, Eq a) => a -> a -> a -> m a
+x ~~> y = \z -> if z == x then return y else mzero
+
+-- | Name instance for Mutable
+instance Mutable Name_ where
+  (==>) = (N .) . (,)
+
+-- | Exp instance for Mutable
+instance Mutable Exp_ where
+  (==>) = (E .) . (,)
+
+-- | Exp instance for Mutable
+instance Mutable Decl_ where
+  (==>) = (D .) . (,)
+
+-- | Literal instance for Mutable
+instance Mutable Literal_ where
+  (==>) = (L .) . (,)
+
+-- | GuardedRhs instance for Mutable
+-- instance Mutable GuardedRhs_ where
+--   (==>) = (G .) . (,)

--- a/src/Test/Mendel/MutationOperator.hs
+++ b/src/Test/Mendel/MutationOperator.hs
@@ -82,7 +82,7 @@ mkMpMuOp (L (x,y)) = G.mkMp (x ~~> y)
 -- mkMpMuOp (G (x,y)) = G.mkMp (x ~~> y) 
 
 -- | Show a specified mutation
-showM :: (Outputable a, Outputable a1) => (a, a1) -> String
+showM :: (Outputable  a, Outputable a1) => (a, a1) -> String
 showM (s, t) = "{\n" ++ showPprUnsafe s ++ "\n} ==> {\n" ++ showPprUnsafe t ++ "\n}"
 
 -- | MuOp instance for Show

--- a/src/Test/Mendel/MutationOperator.hs
+++ b/src/Test/Mendel/MutationOperator.hs
@@ -1,18 +1,110 @@
-{- |
-Module         : Test.Mendel.MutationOperator
-Description    : Definition of mutation operators
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE Rank2Types #-}
 
-This module provides various mutation operators which can be used
-to inject faults into Haskell modules.
--}
-module Test.Mendel.MutationOperator (MuOp (..)) where
+-- | Mutation operators
+module Test.Mendel.MutationOperator (
+    MuOp,
+    Mutable (..),
+    (==>*),
+    (*==>*),
+    (~~>),
+    mkMpMuOp,
+    same,
+    Module_,
+    Exp_ (..),
+    Decl_ (..),
+    getSpan,
+) where
 
-{- | A mutation operator which describes a semantic change that should be applied to
-a Haskell module.
--}
+import Control.Monad (MonadPlus, mzero)
+import Data.Generics qualified as G
+import GHC.Hs
+import GHC.Types.SrcLoc
+import GHC.Utils.Outputable
+import Language.Haskell.GhclibParserEx.GHC.Hs.ExtendInstances
+
+type Module_ = HsModule GhcPs
+
+-- wrapper for 'LHsExpr GhcPs'
+newtype Exp_ = WrpExpr {getExpr :: LHsExpr GhcPs}
+
+-- wrapper for 'LHsDecl GhcPs'
+newtype Decl_ = WrpDecl {getDecl :: LHsDecl GhcPs}
+
+-- | MuOp constructor used to specify mutation transformation
 data MuOp
-    = ReverseString
-    | ReverseClausesInPatternMatch
-    | SwapPlusMinus
-    | SwapIfElse
-    deriving (Show, Eq)
+    = E Exp_ Exp_
+    | D Decl_ Decl_
+
+instance Eq MuOp where
+    (==) (E (WrpExpr x1) (WrpExpr y1)) (E (WrpExpr x2) (WrpExpr y2)) = astEq x1 x2 && astEq y1 y2
+    (==) (D (WrpDecl x1) (WrpDecl y1)) (D (WrpDecl x2) (WrpDecl y2)) = astEq x1 x2 && astEq y1 y2
+    (==) _ _ = False
+
+-- | Show a specified mutation
+showM :: (Outputable a, Outputable b) => a -> b -> String
+showM s t = "{\n" ++ showPprUnsafe s ++ "\n} ==> {\n" ++ showPprUnsafe t ++ "\n}"
+
+-- | MuOp instance for Show
+instance Show MuOp where
+    show (E (WrpExpr x) (WrpExpr y)) = showM x y
+    show (D (WrpDecl x) (WrpDecl y)) = showM x y
+
+-- | getSpan retrieve the span as a tuple
+getSpan :: MuOp -> (Int, Int, Int, Int)
+getSpan m = (startLine, startCol, endLine, endCol)
+  where
+    startLine = getInt srcSpanStartLine lspan
+    startCol = getInt srcSpanStartCol lspan
+    endLine = getInt srcSpanEndLine lspan
+    endCol = getInt srcSpanEndCol lspan
+    getInt :: (RealSrcSpan -> Int) -> Maybe RealSrcSpan -> Int
+    getInt f (Just x) = f x
+    getInt _ Nothing = error "No Source Span"
+    getSpan' (E (WrpExpr a) _) = getLocA a
+    getSpan' (D (WrpDecl a) _) = getLocA a
+    lspan = srcSpanToRealSrcSpan $ getSpan' m
+
+{- | The function `same` applies on a `MuOP` determining if transformation is
+between same values.
+-}
+same :: MuOp -> Bool
+same (E (WrpExpr x) (WrpExpr y)) = astEq x y
+same (D (WrpDecl x) (WrpDecl y)) = astEq x y
+
+-- | A wrapper over mkMp
+mkMpMuOp :: (MonadPlus m, G.Typeable a) => MuOp -> a -> m a
+mkMpMuOp (E x y) = G.mkMp (getExpr x ~~> getExpr y)
+mkMpMuOp (D x y) = G.mkMp (getDecl x ~~> getDecl y)
+
+-- | Mutation operation representing translation from one fn to another fn.
+class Mutable a where
+    (==>) :: a -> a -> MuOp
+
+{- | The function `==>*` pairs up the given element with all elements of the
+second list, and applies `==>` on them.
+-}
+(==>*) :: (Mutable a) => a -> [a] -> [MuOp]
+(==>*) x = map (x ==>)
+
+{- | The function `*==>*` pairs up all elements of first list with all elements
+of second list and applies `==>` between them.
+-}
+(*==>*) :: (Mutable a) => [a] -> [a] -> [MuOp]
+xs *==>* ys = concatMap (==>* ys) xs
+
+{- | The function `~~>` accepts two values, and returns a function
+that if given a value equal to first, returns second
+we handle x ~~> x separately
+-}
+(~~>) :: (MonadPlus m, G.Data a) => a -> a -> a -> m a
+x ~~> y = \z -> if astEq z x then return y else mzero
+
+-- | Exp instance for Mutable
+instance Mutable Exp_ where
+    e1 ==> e2 = E e1 e2
+
+-- | Decl instance for Mutable
+instance Mutable Decl_ where
+    d1 ==> d2 = D d1 d2

--- a/src/Test/Mendel/MutationVariant.hs
+++ b/src/Test/Mendel/MutationVariant.hs
@@ -19,5 +19,6 @@ data MuVariant
   | ReverseString
   | ReverseClausesInPatternMatch
   | SwapPlusMinus
+  | SwapIfElse
 
   deriving (Show, Eq)

--- a/src/Test/Mendel/MutationVariant.hs
+++ b/src/Test/Mendel/MutationVariant.hs
@@ -1,0 +1,24 @@
+{- |
+Module         : Test.Mendel.MutationVariant
+Description    : Definition of mutation operators
+
+This module provides various mutation operators which can be used
+to inject faults into Haskell modules.
+-}
+module Test.Mendel.MutationVariant where
+
+{- | A mutation operator which describes a semantic change that should be applied to
+a Haskell module.
+-}
+data MuVariant
+    = MutatePatternMatch
+    | MutateValues
+    | MutateFunctions
+    | MutateNegateIfElse
+    | MutateNegateGuards
+    | MutateOther String
+    | ReverseString
+    | ReverseClausesInPatternMatch
+    | SwapPlusMinus
+    | SwapIfElse
+    deriving (Show, Eq)

--- a/src/Test/Mendel/MutationVariant.hs
+++ b/src/Test/Mendel/MutationVariant.hs
@@ -5,12 +5,19 @@ Description    : Definition of mutation operators
 This module provides various mutation operators which can be used
 to inject faults into Haskell modules.
 -}
-module Test.Mendel.MutationVariant (MuVariant(..)) where
+module Test.Mendel.MutationVariant where
 
 -- | A mutation operator which describes a semantic change that should be applied to
 -- a Haskell module.
 data MuVariant
-  = ReverseString
+  = MutatePatternMatch
+  | MutateValues
+  | MutateFunctions
+  | MutateNegateIfElse
+  | MutateNegateGuards
+  | MutateOther String
+  | ReverseString
   | ReverseClausesInPatternMatch
   | SwapPlusMinus
+
   deriving (Show, Eq)

--- a/src/Test/Mendel/MutationVariant.hs
+++ b/src/Test/Mendel/MutationVariant.hs
@@ -1,0 +1,16 @@
+{- |
+Module         : Test.Mendel.MutationVariant
+Description    : Definition of mutation operators
+
+This module provides various mutation operators which can be used
+to inject faults into Haskell modules.
+-}
+module Test.Mendel.MutationVariant (MuVariant(..)) where
+
+-- | A mutation operator which describes a semantic change that should be applied to
+-- a Haskell module.
+data MuVariant
+  = ReverseString
+  | ReverseClausesInPatternMatch
+  | SwapPlusMinus
+  deriving (Show, Eq)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -3,6 +3,7 @@ module Main (main) where
 import GHC.Types.SrcLoc qualified as GHC
 import System.FilePath
 import Test.Mendel.Mutation
+import Test.Mendel.MutationOperator
 import Test.Mendel.MutationVariant
 import Test.Mendel.Parser
 import Test.Mendel.Printer (printOutputableToFile)
@@ -57,6 +58,6 @@ mkGoldenTest name muop = goldenVsFile name (goldenDir </> name <.> "hs") (tempDi
         mmod <- parseModule (candidateDir </> name <.> "hs")
         case mmod of
             Just (GHC.L _ hmod) -> do
-                let mutated = mutate muop hmod
+                let mutated = mutate' muop hmod
                 printOutputableToFile mutated (tempDir </> name <.> "hs")
             Nothing -> pure ()

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -3,7 +3,7 @@ module Main (main) where
 import GHC.Types.SrcLoc qualified as GHC
 import System.FilePath
 import Test.Mendel.Mutation
-import Test.Mendel.MutationOperator
+import Test.Mendel.MutationVariant
 import Test.Mendel.Parser
 import Test.Mendel.Printer (printOutputableToFile)
 import Test.Tasty
@@ -49,7 +49,7 @@ candidateDir = baseDir </> "candidate"
 -- Individual tests
 -------------------------------------------------------------------------------
 
-mkGoldenTest :: String -> MuOp -> TestTree
+mkGoldenTest :: String -> MuVariant -> TestTree
 mkGoldenTest name muop = goldenVsFile name (goldenDir </> name <.> "hs") (tempDir </> name <.> "hs") go
   where
     go :: IO ()

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -4,6 +4,7 @@ import GHC.Types.SrcLoc qualified as GHC
 import System.FilePath
 import Test.Mendel.Mutation
 import Test.Mendel.MutationOperator
+import Test.Mendel.MutationVariant
 import Test.Mendel.Parser
 import Test.Mendel.Printer (printOutputableToFile)
 import Test.Tasty
@@ -49,7 +50,7 @@ candidateDir = baseDir </> "candidate"
 -- Individual tests
 -------------------------------------------------------------------------------
 
-mkGoldenTest :: String -> MuOp -> TestTree
+mkGoldenTest :: String -> MuVariant -> TestTree
 mkGoldenTest name muop = goldenVsFile name (goldenDir </> name <.> "hs") (tempDir </> name <.> "hs") go
   where
     go :: IO ()
@@ -57,6 +58,6 @@ mkGoldenTest name muop = goldenVsFile name (goldenDir </> name <.> "hs") (tempDi
         mmod <- parseModule (candidateDir </> name <.> "hs")
         case mmod of
             Just (GHC.L _ hmod) -> do
-                let mutated = mutate muop hmod
+                let mutated = mutate' muop hmod
                 printOutputableToFile mutated (tempDir </> name <.> "hs")
             Nothing -> pure ()

--- a/test/candidate/SwapIfElse.hs
+++ b/test/candidate/SwapIfElse.hs
@@ -1,4 +1,4 @@
-module SwapPlusMinus where
+module SwapIfElse where
 
 swapMe :: Bool -> String
 swapMe x = if x then "True" else "False"

--- a/test/golden/SwapIfElse.hs
+++ b/test/golden/SwapIfElse.hs
@@ -1,3 +1,3 @@
-module SwapPlusMinus where
+module SwapIfElse where
 swapMe :: Bool -> String
 swapMe x = if x then "False" else "True"


### PR DESCRIPTION
- Die Instanz Eq für HsExpr und HsDecl habe ich versucht durch die Funktion toConstr hinzubekommen, wodurch es zumindest mal keine Probleme der Type check erstmal keine Probleme macht.
  Ich weiß aber nicht ob man das einfach so machen kann oder ob das Probleme gibt.

- Die Typen Module_  etc. sind ja eigentlich Wrapper um den Typ mit der SrcSpanInfo zu haben. Bei haskell-src-exts wird die Location bei jedem Typen mitgegeben, wie GhcPass bei ghc-lib-parser.
  Bei ghc-lib-parser ist die Location jedes Teils nur ganz außen in LHsExpr und LHsDecl. Diese Typen sind jedoch nicht mehr mutable, wodurch die ganzen Funktionen nicht mehr darauf anwenden kann.
  Soll ich also für die SrcSpan also nochmals separate Typen machen? Und später dann die SrcSpan und MuOp zsm. in einem Tuple weitergeben? 